### PR TITLE
change endpoint of users POST to be more RESTful

### DIFF
--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -9,7 +9,7 @@ const {
 } = require("../controllers/usersController");
 
 router.get("/", getAllUsers);
-router.post("/create", createUser);
+router.post("/", createUser);
 router.get("/:userId", getSingleUser);
 router.get("/:userId/favorites", getUserFavorites);
 router.get("/:userId/teams", getUserTeams);


### PR DESCRIPTION
This PR:
- remerges POST-user branch with minor change
- change endpoint from POST -> "api/users/create" to POST -> "api/users"
- reasoning: RESTful APIs do not have verbs in the endpoints, POST serves that purpose