### PR TITLE
Client routes to use username and Promise.all

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -24,6 +24,16 @@ const router = createBrowserRouter([
   {
     element: <HomePage />,
     path: "/",
+    loader: async ({ request, params }) => {
+      const { data } = await axios.get("/api/session");
+      if (data) {
+        const userTeamsData = await axios.get(
+          `/api/users/${data.id}/user-teams`
+        );
+        return { userTeamsData };
+      }
+      return null;
+    },
   },
   {
     path: "/",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -44,10 +44,13 @@ const router = createBrowserRouter([
     element: <AuthedLayout />,
     children: [
       {
-        path: "/:userId",
+        path: "/:username",
         element: <UserPage />,
         loader: async ({ request, params }) => {
-          const { userId } = params;
+          const { username } = params;
+          const {
+            data: { userId },
+          } = await axios.get(`/api/users/usernames/${username}`);
           const userData = await axios.get(`/api/users/${userId}`);
           const userTeamData = await axios.get(`/api/users/${userId}/teams`);
           const userTeammates = await axios.get(
@@ -57,32 +60,33 @@ const router = createBrowserRouter([
         },
       },
       {
-        path: "/:userId/favorites",
+        path: "/:username/favorites",
         element: <FavoritesPage />,
         loader: async ({ request, params }) => {
-          const { userId } = params;
-          try {
-            const userFavorites = await axios.get(
-              `/api/users/${userId}/favorites`
-            );
-            return { userFavorites };
-          } catch (error) {
-            console.error(error);
-            return { error };
-          }
+          const { username } = params;
+          const {
+            data: { userId },
+          } = await axios.get(`/api/users/usernames/${username}`);
+          const userFavorites = await axios.get(
+            `/api/users/${userId}/favorites`
+          );
+          return { userFavorites };
         },
       },
       {
-        path: "/:userId/settings",
+        path: "/:username/settings",
         element: <UserSettingsPage />,
         loader: async ({ request, params }) => {
-          const { userId } = params;
+          const { username } = params;
+          const {
+            data: { userId },
+          } = await axios.get(`/api/users/usernames/${username}`);
           const { data } = await axios.get(`/api/users/${userId}`);
           return data;
         },
       },
       {
-        path: "/:userId/settings/delete-account",
+        path: "/:username/settings/delete-account",
         element: <div>DELETE ACCOUNT</div>,
       },
       {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -93,8 +93,12 @@ const router = createBrowserRouter([
         path: "/teams",
         element: <TeamsPage />,
         loader: async ({ request, params }) => {
+          const {
+            data: { id: userId },
+          } = await axios.get("/api/session");
+          const userTeamsData = await axios.get(`/api/users/${userId}/teams`);
           const allTeamsData = await axios.get("/api/teams");
-          return { allTeamsData };
+          return { allTeamsData, userTeamsData };
         },
       },
       {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -96,7 +96,9 @@ const router = createBrowserRouter([
           const {
             data: { id: userId },
           } = await axios.get("/api/session");
-          const userTeamsData = await axios.get(`/api/users/${userId}/teams`);
+          const userTeamsData = await axios.get(
+            `/api/users/${userId}/user-teams`
+          );
           const allTeamsData = await axios.get("/api/teams");
           return { allTeamsData, userTeamsData };
         },

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -61,13 +61,11 @@ const router = createBrowserRouter([
           const {
             data: { userId },
           } = await axios.get(`/api/users/usernames/${username}`);
-          const userData = await axios.get(`/api/users/${userId}`);
-          const userTeamData = await axios.get(
-            `/api/users/${userId}/user-teams`
-          );
-          const userTeammates = await axios.get(
-            `/api/users/${userId}/teammates`
-          );
+          const [userData, userTeamData, userTeammates] = await Promise.all([
+            axios.get(`/api/users/${userId}`),
+            axios.get(`/api/users/${userId}/user-teams`),
+            axios.get(`/api/users/${userId}/teammates`),
+          ]);
           return { userData, userTeamData, userTeammates };
         },
       },
@@ -93,8 +91,8 @@ const router = createBrowserRouter([
           const {
             data: { userId },
           } = await axios.get(`/api/users/usernames/${username}`);
-          const { data } = await axios.get(`/api/users/${userId}`);
-          return data;
+          const userData = await axios.get(`/api/users/${userId}`);
+          return { userData };
         },
       },
       {
@@ -108,10 +106,10 @@ const router = createBrowserRouter([
           const {
             data: { id: userId },
           } = await axios.get("/api/session");
-          const userTeamsData = await axios.get(
-            `/api/users/${userId}/user-teams`
-          );
-          const allTeamsData = await axios.get("/api/teams");
+          const [userTeamsData, allTeamsData] = await Promise.all([
+            axios.get(`/api/users/${userId}/user-teams`),
+            axios.get("/api/teams"),
+          ]);
           return { allTeamsData, userTeamsData };
         },
       },

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -62,7 +62,9 @@ const router = createBrowserRouter([
             data: { userId },
           } = await axios.get(`/api/users/usernames/${username}`);
           const userData = await axios.get(`/api/users/${userId}`);
-          const userTeamData = await axios.get(`/api/users/${userId}/teams`);
+          const userTeamData = await axios.get(
+            `/api/users/${userId}/user-teams`
+          );
           const userTeammates = await axios.get(
             `/api/users/${userId}/teammates`
           );

--- a/client/src/components/Dashboard.js
+++ b/client/src/components/Dashboard.js
@@ -1,27 +1,17 @@
-import AuthedPageTitle from "./AuthedPageTitle";
+import { useLoaderData } from "react-router-dom";
+
+import { useAuth } from "../context/AuthContext";
 import ScrollableList from "./ScrollableList";
+import AuthedPageTitle from "./AuthedPageTitle";
 import FavoriteButton from "./FavoriteButton";
 import DropdownMenuButton from "./DropdownMenuButton";
 import formatDate from "../utils/formatDate";
-import { useEffect, useState } from "react";
-import axios from "axios";
-import { useAuth } from "../context/AuthContext";
 
 const Dashboard = () => {
-  const [userTeams, setUserTeams] = useState([]);
-  const { authedUser } = useAuth();
+  const { userTeamsData } = useLoaderData();
+  const { userTeams } = userTeamsData.data;
 
-  useEffect(() => {
-    const getUserTeams = async () => {
-      const {
-        data: { teams },
-      } = await axios.get(
-        "/api/users/bef0cbf3-6458-4f13-a418-ee4d7e7505da/teams"
-      );
-      setUserTeams(teams);
-    };
-    getUserTeams();
-  }, []);
+  const { authedUser } = useAuth();
 
   const jobListings = [
     {

--- a/client/src/components/Dashboard.js
+++ b/client/src/components/Dashboard.js
@@ -10,7 +10,6 @@ import formatDate from "../utils/formatDate";
 const Dashboard = () => {
   const { userTeamsData } = useLoaderData();
   const { userTeams } = userTeamsData.data;
-
   const { authedUser } = useAuth();
 
   const jobListings = [

--- a/client/src/components/NavDropdownList.js
+++ b/client/src/components/NavDropdownList.js
@@ -11,13 +11,13 @@ const NavDropdownList = () => {
   return (
     <div className="absolute top-3 -right-3 z-10 flex flex-col bg-slate-100 shadow-md text-center border rounded-sm">
       <NavLink
-        to={`/${authedUser?.id}`}
+        to={`/${authedUser?.username}`}
         className="w-36 sm:w-40 hover:bg-blue-200 py-2"
       >
         Profile
       </NavLink>
       <NavLink
-        to={`/${authedUser?.id}/settings`}
+        to={`/${authedUser?.username}/settings`}
         className="w-36 sm:w-40 hover:bg-blue-200 py-2"
       >
         Settings

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -6,7 +6,7 @@ import NavDropdownList from "./NavDropdownList";
 const Navbar = () => {
   const { authedUser } = useAuth();
   const [isListShowing, setIsListShowing] = useState(false);
-  
+
   return (
     <div className="sticky top-0 z-20 p-4 w-full flex items-center h-16 justify-between bg-slate-100 shadow-[0_1px_3px_rgb(0,0,0,0.2)]">
       <div className="flex gap-4 sm:gap-10 items-center">
@@ -17,7 +17,7 @@ const Navbar = () => {
           Teams
         </NavLink>
         <NavLink
-          to={`/${authedUser?.id}/favorites`}
+          to={`/${authedUser?.username}/favorites`}
           className="text-sm sm:text-base"
         >
           Favorites

--- a/client/src/pages/HomePage.js
+++ b/client/src/pages/HomePage.js
@@ -12,7 +12,7 @@ const HomePage = () => {
 
   return (
     <AuthedLayout>
-      <Dashboard />;
+      <Dashboard />
     </AuthedLayout>
   );
 };

--- a/client/src/pages/TeamsPage.js
+++ b/client/src/pages/TeamsPage.js
@@ -19,10 +19,6 @@ const TeamsPage = () => {
     getUserTeams();
   }, [authedUserId]);
 
-  if (!authedUser) {
-    return <Navigate to="/login" />;
-  }
-
   return (
     <div className="flex flex-col">
       <h1 className="text-2xl font-bold">All Teams</h1>

--- a/client/src/pages/TeamsPage.js
+++ b/client/src/pages/TeamsPage.js
@@ -1,23 +1,10 @@
 import { NavLink } from "react-router-dom";
-import { useLoaderData, Navigate } from "react-router-dom";
-import { useAuth } from "../context/AuthContext";
-import { useEffect, useState } from "react";
-import axios from "axios";
+import { useLoaderData } from "react-router-dom";
 
 const TeamsPage = () => {
-  const { allTeamsData } = useLoaderData();
+  const { allTeamsData, userTeamsData } = useLoaderData();
   const { teams } = allTeamsData.data;
-  const { authedUser } = useAuth();
-  const authedUserId = authedUser?.id;
-  const [userTeams, setUserTeams] = useState([]);
-
-  useEffect(() => {
-    const getUserTeams = async () => {
-      const response = await axios.get(`/api/users/${authedUserId}/teams`);
-      setUserTeams(response.data.teams);
-    };
-    getUserTeams();
-  }, [authedUserId]);
+  const { teams: userTeams } = userTeamsData.data;
 
   return (
     <div className="flex flex-col">

--- a/client/src/pages/TeamsPage.js
+++ b/client/src/pages/TeamsPage.js
@@ -4,7 +4,7 @@ import { useLoaderData } from "react-router-dom";
 const TeamsPage = () => {
   const { allTeamsData, userTeamsData } = useLoaderData();
   const { teams } = allTeamsData.data;
-  const { teams: userTeams } = userTeamsData.data;
+  const { userTeams } = userTeamsData.data;
 
   return (
     <div className="flex flex-col">

--- a/client/src/pages/UserPage.js
+++ b/client/src/pages/UserPage.js
@@ -8,7 +8,7 @@ import UserInfo from "../components/UserInfo";
 const UserPage = () => {
   const { userData, userTeamData, userTeammates } = useLoaderData();
   const { user } = userData.data;
-  const { teams } = userTeamData.data;
+  const { userTeams } = userTeamData.data;
   const { teammates } = userTeammates.data;
   const { readme, username } = user;
 
@@ -35,7 +35,7 @@ const UserPage = () => {
       </div>
       <div className="flex flex-col sm:flex-row h-1/3 gap-10">
         <ScrollableList title="Teams" width="sm:w-2/3">
-          {teams.map((team, index) => (
+          {userTeams.map((team, index) => (
             <li
               className="bg-white p-2.5 border-t-[0.5px] border-l-[0.5px] rounded-sm shadow-[0_0.3px_1px_rgba(0,0,0,0.2)] hover:bg-blue-200"
               key={`${team.name}-${index}`}

--- a/client/src/pages/UserSettingsPage.js
+++ b/client/src/pages/UserSettingsPage.js
@@ -6,7 +6,8 @@ import AuthedPageTitle from "../components/AuthedPageTitle";
 import FormField from "../components/FormField";
 
 const UserSettingsPage = () => {
-  const { user } = useLoaderData();
+  const { userData } = useLoaderData();
+  const { user } = userData.data;
   const navigate = useNavigate();
 
   const [firstName, setFirstName] = useState(user.firstName || "");

--- a/server/controllers/usersController.js
+++ b/server/controllers/usersController.js
@@ -68,13 +68,13 @@ const getUserFavorites = async (req, res, next) => {
 const getUserTeams = async (req, res, next) => {
   try {
     const { userId } = req.params;
-    const teams = await User.getUserTeams(userId);
-    if (teams.length === 0) {
-      return res.status(200).json({ message: "No teams exist.", teams });
+    const userTeams = await User.getUserTeams(userId);
+    if (userTeams.length === 0) {
+      return res.status(200).json({ message: "No teams exist.", userTeams });
     }
     res.status(200).json({
       message: "User's teams fetched successfully.",
-      teams,
+      userTeams,
     });
   } catch (error) {
     next(error);

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -146,10 +146,8 @@ const updateUser = async (userId, updates) => {
 
 const getIdByUsername = async (username) => {
   try {
-    const [userId] = await knex("users")
-      .select("id")
-      .where("username", username);
-    return userId.id;
+    const [user] = await knex("users").select("id").where("username", username);
+    return user.id;
   } catch (error) {
     throw new Error("Database Error: " + error.message);
   }

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -149,7 +149,7 @@ const getIdByUsername = async (username) => {
     const [userId] = await knex("users")
       .select("id")
       .where("username", username);
-    return userId;
+    return userId.id;
   } catch (error) {
     throw new Error("Database Error: " + error.message);
   }

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -20,7 +20,7 @@ router.get("/:userId", getSingleUser);
 router.patch("/:userId", updateUser);
 router.delete("/:userId", deleteUser);
 router.get("/:userId/favorites", getUserFavorites);
-router.get("/:userId/teams", getUserTeams);
+router.get("/:userId/user-teams", getUserTeams);
 router.get("/:userId/teammates", getUserTeammates);
 router.get("/usernames/:username", getIdByUsername);
 


### PR DESCRIPTION
This PR combines Jira tickets 52 and 56 and aims to:
- change routes and nav links on the client to use `/:username` instead of `:userId`
- raises data fetching logic of Dashboard and Teams to their appropriate loaders in our router
- renaming a couple response data variables in the backend
- renaming a user's teams endpoint for response clarity
- runs fetches in parallel using Promise.all()