### PR TITLE
Login/signup loading rework

### DIFF
--- a/client/src/components/LoadingSpinner.js
+++ b/client/src/components/LoadingSpinner.js
@@ -2,7 +2,7 @@ const LoadingSpinner = ({ message }) => {
   return (
     <div className="fixed top-0 left-0 w-full h-full flex flex-col items-center justify-center z-50 backdrop-blur-sm">
       <div className="animate-spin rounded-full h-20 w-20 border-t-2 border-b-2 border-gray-900"></div>
-      <p>{message}</p>
+      <p className="mt-2">{message}</p>
     </div>
   );
 };

--- a/client/src/components/LoadingSpinner.js
+++ b/client/src/components/LoadingSpinner.js
@@ -1,7 +1,8 @@
-const LoadingSpinner = () => {
+const LoadingSpinner = ({ message }) => {
   return (
-    <div className="fixed top-0 left-0 w-full h-full flex items-center justify-center z-50 backdrop-blur-sm">
+    <div className="fixed top-0 left-0 w-full h-full flex flex-col items-center justify-center z-50 backdrop-blur-sm">
       <div className="animate-spin rounded-full h-20 w-20 border-t-2 border-b-2 border-gray-900"></div>
+      <p>{message}</p>
     </div>
   );
 };

--- a/client/src/components/UnauthedLayout.js
+++ b/client/src/components/UnauthedLayout.js
@@ -1,4 +1,4 @@
-import { Navigate, Outlet, useLocation, useNavigation } from "react-router-dom";
+import { Navigate, Outlet, useNavigation } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 import Footer from "./Footer";
 import LoadingSpinner from "./LoadingSpinner";

--- a/client/src/components/UnauthedLayout.js
+++ b/client/src/components/UnauthedLayout.js
@@ -1,4 +1,4 @@
-import { Navigate, Outlet, useNavigation } from "react-router-dom";
+import { Navigate, Outlet, useLocation, useNavigation } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 import Footer from "./Footer";
 import LoadingSpinner from "./LoadingSpinner";
@@ -6,11 +6,20 @@ import LoadingSpinner from "./LoadingSpinner";
 const UnauthedLayout = ({ children }) => {
   const { authedUser } = useAuth();
   const navigation = useNavigation();
+  console.log(navigation);
+  const location = useLocation();
+  console.log(location);
 
   if (navigation.state === "loading") {
     return (
       <>
-        <LoadingSpinner />
+        <LoadingSpinner
+          message={
+            location.pathname === "/login"
+              ? "Logging in..."
+              : "Creating user..."
+          }
+        />
         <div className="flex flex-col justify-center items-center min-h-[calc(100vh-4rem)]">
           {children || <Outlet />}
         </div>

--- a/client/src/components/UnauthedLayout.js
+++ b/client/src/components/UnauthedLayout.js
@@ -7,13 +7,24 @@ const UnauthedLayout = ({ children }) => {
   const { authedUser } = useAuth();
   const navigation = useNavigation();
 
+  if (navigation.state === "loading") {
+    return (
+      <>
+        <LoadingSpinner />
+        <div className="flex flex-col justify-center items-center min-h-[calc(100vh-4rem)]">
+          {children || <Outlet />}
+        </div>
+        <Footer />
+      </>
+    );
+  }
+
   if (authedUser) {
     return <Navigate to="/" />;
   }
 
   return (
     <>
-      {navigation.state === "loading" && <LoadingSpinner />}
       <div className="flex flex-col justify-center items-center min-h-[calc(100vh-4rem)]">
         {children || <Outlet />}
       </div>

--- a/client/src/components/UnauthedLayout.js
+++ b/client/src/components/UnauthedLayout.js
@@ -6,20 +6,11 @@ import LoadingSpinner from "./LoadingSpinner";
 const UnauthedLayout = ({ children }) => {
   const { authedUser } = useAuth();
   const navigation = useNavigation();
-  console.log(navigation);
-  const location = useLocation();
-  console.log(location);
 
   if (navigation.state === "loading") {
     return (
       <>
-        <LoadingSpinner
-          message={
-            location.pathname === "/login"
-              ? "Logging in..."
-              : "Creating user..."
-          }
-        />
+        <LoadingSpinner message={"Redirecting..."} />
         <div className="flex flex-col justify-center items-center min-h-[calc(100vh-4rem)]">
           {children || <Outlet />}
         </div>


### PR DESCRIPTION
- Correctly checks for loading state in UnauthedLayout to display a loading spinner
- Reduces blank screen render time on logging in, signing up, and redirects
- Was unable to customize messages based off of the above 3 scenarios. Was able to customize messages for signup and login, however, was unable to create a proper check for redirects, resulting in poor messaging when an authed user is being redirected from login and signup pages. As a result, decided to use a universal "Redirecting..." message.

![image](https://user-images.githubusercontent.com/40076376/233471781-130d4739-7dc8-45ce-9617-25069c8645d6.png)
