### PR TITLE
User API Rework (Part 1)

### DIFF
--- a/client/src/pages/CreateListingPage.js
+++ b/client/src/pages/CreateListingPage.js
@@ -123,12 +123,12 @@ export const CreateListingPage = () => {
 
 export const createListingLoader = async ({ request, params }) => {
   const { teamId } = params;
-  const [singleTeamData, teammatesData] = await Promise.all([
+  const [singleTeamResponse, teammatesResponse] = await Promise.all([
     axios.get(`/api/teams/${teamId}`),
     axios.get(`/api/teams/${teamId}/teammates`),
   ]);
 
-  const singleTeam = singleTeamData.data;
-  const teammates = teammatesData.data;
+  const singleTeam = singleTeamResponse.data;
+  const teammates = teammatesResponse.data;
   return { singleTeam, teammates };
 };

--- a/client/src/pages/DeleteListingPage.js
+++ b/client/src/pages/DeleteListingPage.js
@@ -63,13 +63,13 @@ export const DeleteListingPage = () => {
 
 export const deleteListingLoader = async ({ request, params }) => {
   const { listingId, teamId } = params;
-  const [listingData, teammatesData] = await Promise.all([
+  const [listingResponse, teammatesResponse] = await Promise.all([
     axios.get(`/api/listings/${listingId}`),
     axios.get(`/api/teams/${teamId}/teammates`),
   ]);
 
-  const listing = listingData.data;
-  const teammates = teammatesData.data;
+  const listing = listingResponse.data;
+  const teammates = teammatesResponse.data;
 
   return { listing, teammates };
 };

--- a/client/src/pages/DeleteTeamPage.js
+++ b/client/src/pages/DeleteTeamPage.js
@@ -57,11 +57,11 @@ export const DeleteTeamPage = () => {
 
 export const deleteTeamLoader = async ({ request, params }) => {
   const { teamId } = params;
-  const [teamData, teammatesData] = await Promise.all([
+  const [teamResponse, teammatesResponse] = await Promise.all([
     axios.get(`/api/teams/${teamId}`),
     axios.get(`/api/teams/${teamId}/teammates`),
   ]);
-  const team = teamData.data;
-  const teammates = teammatesData.data;
+  const team = teamResponse.data;
+  const teammates = teammatesResponse.data;
   return { team, teammates };
 };

--- a/client/src/pages/EditListingPage.js
+++ b/client/src/pages/EditListingPage.js
@@ -129,13 +129,13 @@ export const EditListingPage = () => {
 
 export const editListingLoader = async ({ request, params }) => {
   const { listingId, teamId } = params;
-  const [listingData, teammatesData] = await Promise.all([
+  const [listingResponse, teammatesResponse] = await Promise.all([
     axios.get(`/api/listings/${listingId}`),
     axios.get(`/api/teams/${teamId}/teammates`),
   ]);
 
-  const listing = listingData.data;
-  const teammates = teammatesData.data;
+  const listing = listingResponse.data;
+  const teammates = teammatesResponse.data;
 
   return { listing, teammates };
 };

--- a/client/src/pages/FavoritesPage.js
+++ b/client/src/pages/FavoritesPage.js
@@ -55,9 +55,8 @@ export const FavoritesPage = () => {
 
 export const favoritesLoader = async ({ request, params }) => {
   const { username } = params;
-  const { data: userId } = await axios.get(`/api/users/usernames/${username}`);
-  const favoritesData = await axios.get(`/api/users/${userId}/favorites`);
-  const favorites = favoritesData.data;
+  const userResponse = await axios.get(`/api/users/${username}`);
+  const { favorites } = userResponse.data;
 
   return { favorites };
 };

--- a/client/src/pages/HomePage.js
+++ b/client/src/pages/HomePage.js
@@ -23,16 +23,16 @@ export const HomePage = () => {
 export const homeLoader = async ({ request, params }) => {
   const { data } = await axios.get("/api/session");
   if (data) {
-    const [userTeamsData, recommendedTeamsData] = await Promise.all([
-      axios.get(`/api/users/${data.id}/user-teams`),
+    const [userResponse, recommendedTeamsResponse] = await Promise.all([
+      axios.get(`/api/users/${data.username}`),
       axios.get(`/api/teams/recommended/${data.id}`),
     ]);
 
-    const recommendedTeams = shuffle(recommendedTeamsData.data).slice(0, 4);
-    const userTeams = userTeamsData.data.filter(
+    const recommendedTeams = shuffle(recommendedTeamsResponse.data).slice(0, 4);
+    const userTeams = userResponse.data.teams.filter(
       (team) => team.status !== "invited" && team.status !== "requested"
     );
-    const invites = userTeamsData.data.filter(
+    const invites = userResponse.data.teams.filter(
       (team) => team.status === "invited"
     );
     return { userTeams, invites, recommendedTeams };

--- a/client/src/pages/ListingDetailsPage.js
+++ b/client/src/pages/ListingDetailsPage.js
@@ -124,22 +124,27 @@ export const listingDetailsLoader = async ({ request, params }) => {
   const { teamId, listingId } = params;
   const { data } = await axios.get("/api/session");
   if (data) {
-    const [teamData, teammatesData, listingData, favoritesData, commentsData] =
-      await Promise.all([
-        axios.get(`/api/teams/${teamId}`),
-        axios.get(`/api/teams/${teamId}/teammates`),
-        axios.get(`/api/listings/${listingId}`),
-        axios.get(`/api/users/${data.id}/favorites`),
-        axios.get(`/api/comments/${listingId}`),
-      ]);
+    const [
+      teamResponse,
+      teammatesResponse,
+      listingResponse,
+      userResponse,
+      commentsResponse,
+    ] = await Promise.all([
+      axios.get(`/api/teams/${teamId}`),
+      axios.get(`/api/teams/${teamId}/teammates`),
+      axios.get(`/api/listings/${listingId}`),
+      axios.get(`/api/users/${data.username}`),
+      axios.get(`/api/comments/${listingId}`),
+    ]);
 
-    const team = teamData.data;
-    const teammates = teammatesData.data.filter(
+    const team = teamResponse.data;
+    const teammates = teammatesResponse.data.filter(
       (tm) => tm.status !== "invited" && tm.status !== "requested"
     );
-    const listing = listingData.data;
-    const favorites = favoritesData.data;
-    const comments = commentsData.data;
+    const listing = listingResponse.data;
+    const { favorites } = userResponse.data;
+    const comments = commentsResponse.data;
 
     return { team, teammates, listing, favorites, comments };
   }

--- a/client/src/pages/TeamPage.js
+++ b/client/src/pages/TeamPage.js
@@ -250,20 +250,24 @@ export const teamLoader = async ({ request, params }) => {
   const { teamId } = params;
   const { data } = await axios.get("/api/session");
   if (data) {
-    const [singleTeamData, teammatesData, listingsData, favoritesData] =
-      await Promise.all([
-        axios.get(`/api/teams/${teamId}`),
-        axios.get(`/api/teams/${teamId}/teammates`),
-        axios.get(`/api/teams/${teamId}/listings`),
-        axios.get(`/api/users/${data.id}/favorites`),
-      ]);
-    const favorites = favoritesData.data;
-    const singleTeam = singleTeamData.data;
-    const listings = listingsData.data;
-    const teammates = teammatesData.data.filter(
+    const [
+      singleTeamResponse,
+      teammatesResponse,
+      listingsResponse,
+      userResponse,
+    ] = await Promise.all([
+      axios.get(`/api/teams/${teamId}`),
+      axios.get(`/api/teams/${teamId}/teammates`),
+      axios.get(`/api/teams/${teamId}/listings`),
+      axios.get(`/api/users/${data.username}`),
+    ]);
+    const { favorites } = userResponse.data;
+    const singleTeam = singleTeamResponse.data;
+    const listings = listingsResponse.data;
+    const teammates = teammatesResponse.data.filter(
       (tm) => tm.status !== "invited" && tm.status !== "requested"
     );
-    const requested = teammatesData.data.filter(
+    const requested = teammatesResponse.data.filter(
       (tm) => tm.status === "requested"
     );
     const authorizedTeammates = teammates

--- a/client/src/pages/TeamSettingsPage.js
+++ b/client/src/pages/TeamSettingsPage.js
@@ -126,12 +126,12 @@ export const TeamSettingsPage = () => {
 
 export const teamSettingsLoader = async ({ request, params }) => {
   const { teamId } = params;
-  const [teamData, teammatesData] = await Promise.all([
+  const [teamResponse, teammatesResponse] = await Promise.all([
     axios.get(`/api/teams/${teamId}`),
     axios.get(`/api/teams/${teamId}/teammates`),
   ]);
-  const team = teamData.data;
-  const teammates = teammatesData.data;
+  const team = teamResponse.data;
+  const teammates = teammatesResponse.data;
   const [ownerId] = teammates
     .filter((tm) => tm.status === "owner")
     .reduce((acc, tm) => {

--- a/client/src/pages/TeamsPage.js
+++ b/client/src/pages/TeamsPage.js
@@ -71,13 +71,13 @@ export const TeamsPage = () => {
 export const teamsLoader = async ({ request, params }) => {
   const { data } = await axios.get("/api/session");
   if (data) {
-    const { id: userId } = data;
-    const [userTeamsData, allTeamsData] = await Promise.all([
-      axios.get(`/api/users/${userId}/user-teams`),
+    const { username } = data;
+    const [userResponse, allTeamsResponse] = await Promise.all([
+      axios.get(`/api/users/${username}`),
       axios.get("/api/teams"),
     ]);
-    const teams = allTeamsData.data;
-    const userTeams = userTeamsData.data;
+    const teams = allTeamsResponse.data;
+    const { teams: userTeams } = userResponse.data;
     return { teams, userTeams };
   }
   return null;

--- a/client/src/pages/UserPage.js
+++ b/client/src/pages/UserPage.js
@@ -8,7 +8,7 @@ import UserInfo from "../components/UserInfo";
 import { useAuth } from "../context/AuthContext";
 
 export const UserPage = () => {
-  const { user, teammates, userTeams } = useLoaderData();
+  const { user, teammates, teams } = useLoaderData();
   const { authedUser } = useAuth();
 
   const { readme, username } = user;
@@ -53,7 +53,7 @@ export const UserPage = () => {
       </div>
       <div className="flex flex-col sm:flex-row h-1/3 gap-10">
         <ScrollableList title="Teams" width="sm:w-2/3">
-          {userTeams.map((team, index) => (
+          {teams.map((team, index) => (
             <NavLink
               to={`/teams/${team.id}`}
               className="bg-white p-2.5 border-t-[0.5px] border-l-[0.5px] rounded-sm shadow-[0_0.3px_1px_rgba(0,0,0,0.2)] hover:bg-blue-200"
@@ -82,17 +82,19 @@ export const UserPage = () => {
 
 export const userLoader = async ({ request, params }) => {
   const { username } = params;
-  const { data: userId } = await axios.get(`/api/users/usernames/${username}`);
-  const [userData, userTeamsData, userTeammates] = await Promise.all([
-    axios.get(`/api/users/${userId}`),
-    axios.get(`/api/users/${userId}/user-teams`),
-    axios.get(`/api/users/${userId}/teammates`),
-  ]);
-
-  const user = userData.data;
-  const teammates = userTeammates.data;
-  const userTeams = userTeamsData.data.filter(
-    (team) => team.status !== "invited" && team.status !== "requested"
-  );
-  return { user, teammates, userTeams };
+  const userResponse = await axios.get(`/api/users/${username}`);
+  const { user, teammates, teams } = userResponse.data;
+  // const { data: userId } = await axios.get(`/api/users/usernames/${username}`);
+  // const [userData, userTeamsData, userTeammates] = await Promise.all([
+  //   axios.get(`/api/users/${userId}`),
+  //   axios.get(`/api/users/${userId}/user-teams`),
+  //   axios.get(`/api/users/${userId}/teammates`),
+  // ]);
+  // const user = userData.data;
+  // const teammates = userTeammates.data;
+  // const userTeams = userTeamsData.data.filter(
+  //   (team) => team.status !== "invited" && team.status !== "requested"
+  // );
+  return { user, teammates, teams };
+  // return { user, teammates, userTeams };
 };

--- a/client/src/pages/UserPage.js
+++ b/client/src/pages/UserPage.js
@@ -84,17 +84,14 @@ export const userLoader = async ({ request, params }) => {
   const { username } = params;
   const userResponse = await axios.get(`/api/users/${username}`);
   const { user, teammates, teams } = userResponse.data;
-  // const { data: userId } = await axios.get(`/api/users/usernames/${username}`);
-  // const [userData, userTeamsData, userTeammates] = await Promise.all([
-  //   axios.get(`/api/users/${userId}`),
-  //   axios.get(`/api/users/${userId}/user-teams`),
-  //   axios.get(`/api/users/${userId}/teammates`),
-  // ]);
-  // const user = userData.data;
-  // const teammates = userTeammates.data;
-  // const userTeams = userTeamsData.data.filter(
-  //   (team) => team.status !== "invited" && team.status !== "requested"
-  // );
-  return { user, teammates, teams };
-  // return { user, teammates, userTeams };
+
+  const filteredTeams = teams.filter(
+    (team) => team.status !== "invited" && team.status !== "requested"
+  );
+
+  return {
+    user,
+    teammates,
+    teams: filteredTeams,
+  };
 };

--- a/client/src/pages/UserSettingsPage.js
+++ b/client/src/pages/UserSettingsPage.js
@@ -171,9 +171,8 @@ export const UserSettingsPage = () => {
 
 export const userSettingsLoader = async ({ request, params }) => {
   const { username } = params;
-  const { data: userId } = await axios.get(`/api/users/usernames/${username}`);
-  const userData = await axios.get(`/api/users/${userId}`);
-  const user = userData.data;
+  const userResponse = await axios.get(`/api/users/${username}`);
+  const { user } = userResponse.data;
 
   return { user };
 };

--- a/server/controllers/sessionController.js
+++ b/server/controllers/sessionController.js
@@ -2,7 +2,7 @@ const { setTokenCookie } = require("../utils/auth");
 
 const User = require("../models/User");
 
-const getSessionUser = async (req, res) => {
+const getSession = async (req, res) => {
   const { user } = req;
   if (user) {
     return res.status(200).json(user);
@@ -33,5 +33,5 @@ const logoutUser = (req, res) => {
 module.exports = {
   loginUser,
   logoutUser,
-  getSessionUser,
+  getSession,
 };

--- a/server/controllers/usersController.js
+++ b/server/controllers/usersController.js
@@ -26,7 +26,7 @@ const getAllUsers = async (req, res, next) => {
   }
 };
 
-const getSingleUser = async (req, res, next) => {
+const getUser = async (req, res, next) => {
   try {
     const { username } = req.params;
     const userId = await User.getIdByUsername(username);
@@ -107,7 +107,7 @@ const updateUser = async (req, res, next) => {
 module.exports = {
   createUser,
   getAllUsers,
-  getSingleUser,
+  getUser,
   addUserFavorite,
   deleteUserFavorite,
   deleteUser,

--- a/server/controllers/usersController.js
+++ b/server/controllers/usersController.js
@@ -35,7 +35,7 @@ const getSingleUser = async (req, res, next) => {
     const teams = await User.getUserTeams(userId);
     const teammates = await User.getUserTeammates(userId);
 
-    res.status(200).json({ ...user, favorites, teams, teammates });
+    res.status(200).json({ user, favorites, teams, teammates });
   } catch (error) {
     next(error);
   }

--- a/server/controllers/usersController.js
+++ b/server/controllers/usersController.js
@@ -41,17 +41,6 @@ const getSingleUser = async (req, res, next) => {
   }
 };
 
-const getUserFavorites = async (req, res, next) => {
-  try {
-    const { userId } = req.params;
-    const favorites = await User.getUserFavorites(userId);
-
-    res.status(200).json(favorites);
-  } catch (error) {
-    next(error);
-  }
-};
-
 const addUserFavorite = async (req, res, next) => {
   try {
     const { userId } = req.params;
@@ -75,27 +64,6 @@ const deleteUserFavorite = async (req, res, next) => {
       });
     }
     res.status(200).json(deletedFavorite);
-  } catch (error) {
-    next(error);
-  }
-};
-
-const getUserTeams = async (req, res, next) => {
-  try {
-    const { userId } = req.params;
-    const userTeams = await User.getUserTeams(userId);
-
-    res.status(200).json(userTeams);
-  } catch (error) {
-    next(error);
-  }
-};
-
-const getUserTeammates = async (req, res, next) => {
-  try {
-    const { userId } = req.params;
-    const teammates = await User.getUserTeammates(userId);
-    res.status(200).json(teammates);
   } catch (error) {
     next(error);
   }
@@ -136,31 +104,12 @@ const updateUser = async (req, res, next) => {
   }
 };
 
-const getIdByUsername = async (req, res, next) => {
-  try {
-    const { username } = req.params;
-    const userId = await User.getIdByUsername(username);
-    if (!userId) {
-      return res.status(404).json({
-        message: `User with username ${username} not found.`,
-      });
-    }
-    res.status(200).json(userId);
-  } catch (error) {
-    next(error);
-  }
-};
-
 module.exports = {
   createUser,
   getAllUsers,
   getSingleUser,
-  getUserFavorites,
   addUserFavorite,
   deleteUserFavorite,
-  getUserTeams,
-  getUserTeammates,
   deleteUser,
   updateUser,
-  getIdByUsername,
 };

--- a/server/controllers/usersController.js
+++ b/server/controllers/usersController.js
@@ -28,9 +28,14 @@ const getAllUsers = async (req, res, next) => {
 
 const getSingleUser = async (req, res, next) => {
   try {
-    const { userId } = req.params;
+    const { username } = req.params;
+    const userId = await User.getIdByUsername(username);
     const user = await User.getSingleUser(userId);
-    res.status(200).json(user);
+    const favorites = await User.getUserFavorites(userId);
+    const teams = await User.getUserTeams(userId);
+    const teammates = await User.getUserTeammates(userId);
+
+    res.status(200).json({ ...user, favorites, teams, teammates });
   } catch (error) {
     next(error);
   }

--- a/server/routes/listings.js
+++ b/server/routes/listings.js
@@ -6,12 +6,6 @@ const {
   deleteListing,
   updateListing,
 } = require("../controllers/listingsController");
-const { route } = require("./teams");
-
-/* GET listings. */
-router.get("/", function (req, res, next) {
-  res.json({ users: ["listingOne", "listingTwo", "listingThree"] });
-});
 
 router.post("/", createListing);
 router.get("/:listingId", getSingleListing);

--- a/server/routes/session.js
+++ b/server/routes/session.js
@@ -5,11 +5,15 @@ const { validateLogin } = require("../utils/validation");
 const {
   loginUser,
   logoutUser,
-  getSessionUser,
+  getSession,
 } = require("../controllers/sessionController");
 
-router.get("/", getSessionUser);
+router.get("/", getSession);
 router.post("/", validateLogin, loginUser);
 router.delete("/", logoutUser);
+
+// router.get("/user", getUser)     *public and private data
+// router.patch("/user", updateUser)   *needs a check against sessionedUser
+// router.delete("/user", deleteUser)   *needs a check against sessionedUser
 
 module.exports = router;

--- a/server/routes/session.js
+++ b/server/routes/session.js
@@ -8,11 +8,14 @@ const {
   getSession,
 } = require("../controllers/sessionController");
 
+// getSession may be gone, this data will come with the potential /user route below
 router.get("/", getSession);
+
 router.post("/", validateLogin, loginUser);
 router.delete("/", logoutUser);
 
 // router.get("/user", getUser)     *public and private data
+// router.post("/user", createUser)
 // router.patch("/user", updateUser)   *needs a check against sessionedUser
 // router.delete("/user", deleteUser)   *needs a check against sessionedUser
 

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -18,12 +18,14 @@ const {
 
 router.get("/", getAllUsers);
 router.post("/", validateSignup, createUser);
-router.get("/:userId", getSingleUser);
-router.patch("/:userId", updateUser);
-router.delete("/:userId", deleteUser);
-router.get("/:userId/favorites", getUserFavorites);
+router.get("/:username", getSingleUser);
+router.patch("/:username", updateUser);
+router.delete("/:username", deleteUser);
+
 router.post("/:userId/favorites", addUserFavorite);
 router.delete("/:userId/favorites", deleteUserFavorite);
+
+router.get("/:userId/favorites", getUserFavorites);
 router.get("/:userId/user-teams", getUserTeams);
 router.get("/:userId/teammates", getUserTeammates);
 router.get("/usernames/:username", getIdByUsername);

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -14,10 +14,15 @@ const {
 
 router.get("/", getAllUsers);
 router.post("/", validateSignup, createUser);
+
+// This needs to be modified to only return public data
 router.get("/:username", getSingleUser);
+
+// These two will move to session, needs to be authorized against session user
 router.patch("/:userId", updateUser);
 router.delete("/:userId", deleteUser);
 
+// These also need to find a new home, these are always private
 router.post("/:userId/favorites", addUserFavorite);
 router.delete("/:userId/favorites", deleteUserFavorite);
 

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -4,7 +4,7 @@ const router = express.Router();
 const { validateSignup } = require("../utils/validation");
 const {
   getAllUsers,
-  getSingleUser,
+  getUser,
   addUserFavorite,
   deleteUserFavorite,
   createUser,
@@ -16,7 +16,7 @@ router.get("/", getAllUsers);
 router.post("/", validateSignup, createUser);
 
 // This needs to be modified to only return public data
-router.get("/:username", getSingleUser);
+router.get("/:username", getUser);
 
 // These two will move to session, needs to be authorized against session user
 router.patch("/:userId", updateUser);

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -5,15 +5,11 @@ const { validateSignup } = require("../utils/validation");
 const {
   getAllUsers,
   getSingleUser,
-  getUserFavorites,
   addUserFavorite,
   deleteUserFavorite,
-  getUserTeams,
   createUser,
-  getUserTeammates,
   deleteUser,
   updateUser,
-  getIdByUsername,
 } = require("../controllers/usersController");
 
 router.get("/", getAllUsers);
@@ -24,10 +20,5 @@ router.delete("/:userId", deleteUser);
 
 router.post("/:userId/favorites", addUserFavorite);
 router.delete("/:userId/favorites", deleteUserFavorite);
-
-router.get("/:userId/favorites", getUserFavorites);
-router.get("/:userId/user-teams", getUserTeams);
-router.get("/:userId/teammates", getUserTeammates);
-router.get("/usernames/:username", getIdByUsername);
 
 module.exports = router;

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -19,8 +19,8 @@ const {
 router.get("/", getAllUsers);
 router.post("/", validateSignup, createUser);
 router.get("/:username", getSingleUser);
-router.patch("/:username", updateUser);
-router.delete("/:username", deleteUser);
+router.patch("/:userId", updateUser);
+router.delete("/:userId", deleteUser);
 
 router.post("/:userId/favorites", addUserFavorite);
 router.delete("/:userId/favorites", deleteUserFavorite);


### PR DESCRIPTION
- Begins work to bring clarity to our User API
     - Bundles user data models into one universal getUser route
     - TODO:    Only return public data in the User API
     - TODO:    For data relevant to the session user, move those calls to the Session API. This will include:
         - Getting private user data(uuid, favorites, email, etc)
         - Moving createUser, updateUser, and deleteUser to this API
         - NOTE 1:    This will provide protection, sessioned users can only view their own private information and update/delete themselves
         - NOTE 2:   This should remove excess calls to the session by just accessing req.user
- Variable renaming for axios fetches (variableNameData  ---> variableNameResponse)
- NOTE 1:  The most important changes will be found usersControler.js and users.js (routes)
- NOTE 2:  This is only the very beginning of the API rework. With these changes, everything should still work. Sessioned user is still unprotected and unsessioned users still have their private information coming through. 