### PR TITLE
User api rework 2

### DIFF
--- a/client/src/components/FavoriteButton.js
+++ b/client/src/components/FavoriteButton.js
@@ -14,25 +14,18 @@ const FavoriteButton = ({ listing, dimensions }) => {
       }, [])
       .includes(listing.id)
   );
-  const { authedUser } = useAuth();
 
   const handleToggleFavorite = async () => {
     if (isFavorite) {
       try {
-        await axios.delete(`/api/users/${authedUser.id}/favorites`, {
-          data: {
-            listingId: listing.id,
-          },
-        });
+        await axios.delete(`/api/listings/${listing.id}/favorites`);
         setIsFavorite(false);
       } catch (error) {
         console.error(error);
       }
     } else {
       try {
-        await axios.post(`/api/users/${authedUser.id}/favorites`, {
-          listingId: listing.id,
-        });
+        await axios.post(`/api/listings/${listing.id}/favorites`);
         setIsFavorite(true);
       } catch (error) {
         console.error(error);

--- a/client/src/context/AuthContext.js
+++ b/client/src/context/AuthContext.js
@@ -27,7 +27,7 @@ export const AuthProvider = ({ children }) => {
       password,
     };
 
-    const { data: user } = await axios.post("/api/users/", newUserData);
+    const { data: user } = await axios.post("/api/users", newUserData);
     setAuthedUser(user);
   };
 

--- a/client/src/pages/DeleteAccountPage.js
+++ b/client/src/pages/DeleteAccountPage.js
@@ -7,7 +7,7 @@ export const DeleteAccountPage = () => {
   const { authedUser, logout } = useAuth();
 
   const handleDelete = async () => {
-    await axios.delete(`/api/users/${authedUser.id}`);
+    await axios.delete("/api/session/user");
     logout();
   };
   return (

--- a/client/src/pages/DeleteListingPage.js
+++ b/client/src/pages/DeleteListingPage.js
@@ -6,8 +6,8 @@ export const DeleteListingPage = () => {
   const { listing } = useLoaderData();
   const navigate = useNavigate();
 
-  const handleDelete = () => {
-    axios.delete(`/api/listings/${listing.id}`);
+  const handleDelete = async () => {
+    await axios.delete(`/api/listings/${listing.id}`);
     navigate(`/teams/${listing.teamId}`);
   };
 

--- a/client/src/pages/FavoritesPage.js
+++ b/client/src/pages/FavoritesPage.js
@@ -54,8 +54,7 @@ export const FavoritesPage = () => {
 };
 
 export const favoritesLoader = async ({ request, params }) => {
-  const { username } = params;
-  const userResponse = await axios.get(`/api/users/${username}`);
+  const userResponse = await axios.get("/api/session/user");
   const { favorites } = userResponse.data;
 
   return { favorites };

--- a/client/src/pages/HomePage.js
+++ b/client/src/pages/HomePage.js
@@ -21,21 +21,16 @@ export const HomePage = () => {
 };
 
 export const homeLoader = async ({ request, params }) => {
-  const { data } = await axios.get("/api/session");
-  if (data) {
-    const [userResponse, recommendedTeamsResponse] = await Promise.all([
-      axios.get(`/api/users/${data.username}`),
-      axios.get(`/api/teams/recommended/${data.id}`),
-    ]);
-
-    const recommendedTeams = shuffle(recommendedTeamsResponse.data).slice(0, 4);
-    const userTeams = userResponse.data.teams.filter(
-      (team) => team.status !== "invited" && team.status !== "requested"
-    );
-    const invites = userResponse.data.teams.filter(
-      (team) => team.status === "invited"
-    );
-    return { userTeams, invites, recommendedTeams };
-  }
-  return null;
+  const userResponse = await axios.get("/api/session/user");
+  const recommendedTeams = shuffle(userResponse.data.recommendedTeams).slice(
+    0,
+    4
+  );
+  const userTeams = userResponse.data.teams.filter(
+    (team) => team.status !== "invited" && team.status !== "requested"
+  );
+  const invites = userResponse.data.teams.filter(
+    (team) => team.status === "invited"
+  );
+  return { userTeams, invites, recommendedTeams };
 };

--- a/client/src/pages/ListingDetailsPage.js
+++ b/client/src/pages/ListingDetailsPage.js
@@ -122,31 +122,28 @@ export const ListingDetailsPage = () => {
 
 export const listingDetailsLoader = async ({ request, params }) => {
   const { teamId, listingId } = params;
-  const { data } = await axios.get("/api/session");
-  if (data) {
-    const [
-      teamResponse,
-      teammatesResponse,
-      listingResponse,
-      userResponse,
-      commentsResponse,
-    ] = await Promise.all([
-      axios.get(`/api/teams/${teamId}`),
-      axios.get(`/api/teams/${teamId}/teammates`),
-      axios.get(`/api/listings/${listingId}`),
-      axios.get(`/api/users/${data.username}`),
-      axios.get(`/api/comments/${listingId}`),
-    ]);
 
-    const team = teamResponse.data;
-    const teammates = teammatesResponse.data.filter(
-      (tm) => tm.status !== "invited" && tm.status !== "requested"
-    );
-    const listing = listingResponse.data;
-    const { favorites } = userResponse.data;
-    const comments = commentsResponse.data;
+  const [
+    teamResponse,
+    teammatesResponse,
+    listingResponse,
+    userResponse,
+    commentsResponse,
+  ] = await Promise.all([
+    axios.get(`/api/teams/${teamId}`),
+    axios.get(`/api/teams/${teamId}/teammates`),
+    axios.get(`/api/listings/${listingId}`),
+    axios.get("/api/session/user"),
+    axios.get(`/api/comments/${listingId}`),
+  ]);
 
-    return { team, teammates, listing, favorites, comments };
-  }
-  return null;
+  const team = teamResponse.data;
+  const teammates = teammatesResponse.data.filter(
+    (tm) => tm.status !== "invited" && tm.status !== "requested"
+  );
+  const listing = listingResponse.data;
+  const { favorites } = userResponse.data;
+  const comments = commentsResponse.data;
+
+  return { team, teammates, listing, favorites, comments };
 };

--- a/client/src/pages/TeamPage.js
+++ b/client/src/pages/TeamPage.js
@@ -248,42 +248,38 @@ export const TeamPage = () => {
 
 export const teamLoader = async ({ request, params }) => {
   const { teamId } = params;
-  const { data } = await axios.get("/api/session");
-  if (data) {
-    const [
-      singleTeamResponse,
-      teammatesResponse,
-      listingsResponse,
-      userResponse,
-    ] = await Promise.all([
-      axios.get(`/api/teams/${teamId}`),
-      axios.get(`/api/teams/${teamId}/teammates`),
-      axios.get(`/api/teams/${teamId}/listings`),
-      axios.get(`/api/users/${data.username}`),
-    ]);
-    const { favorites } = userResponse.data;
-    const singleTeam = singleTeamResponse.data;
-    const listings = listingsResponse.data;
-    const teammates = teammatesResponse.data.filter(
-      (tm) => tm.status !== "invited" && tm.status !== "requested"
-    );
-    const requested = teammatesResponse.data.filter(
-      (tm) => tm.status === "requested"
-    );
-    const authorizedTeammates = teammates
-      .filter((tm) => tm.status === "owner" || tm.status === "admin")
-      .reduce((acc, tm) => {
-        acc.push(tm.id);
-        return acc;
-      }, []);
-    return {
-      singleTeam,
-      teammates,
-      requested,
-      authorizedTeammates,
-      favorites,
-      listings,
-    };
-  }
-  return null;
+  const [
+    singleTeamResponse,
+    teammatesResponse,
+    listingsResponse,
+    userResponse,
+  ] = await Promise.all([
+    axios.get(`/api/teams/${teamId}`),
+    axios.get(`/api/teams/${teamId}/teammates`),
+    axios.get(`/api/teams/${teamId}/listings`),
+    axios.get("/api/session/user"),
+  ]);
+  const { favorites } = userResponse.data;
+  const singleTeam = singleTeamResponse.data;
+  const listings = listingsResponse.data;
+  const teammates = teammatesResponse.data.filter(
+    (tm) => tm.status !== "invited" && tm.status !== "requested"
+  );
+  const requested = teammatesResponse.data.filter(
+    (tm) => tm.status === "requested"
+  );
+  const authorizedTeammates = teammates
+    .filter((tm) => tm.status === "owner" || tm.status === "admin")
+    .reduce((acc, tm) => {
+      acc.push(tm.id);
+      return acc;
+    }, []);
+  return {
+    singleTeam,
+    teammates,
+    requested,
+    authorizedTeammates,
+    favorites,
+    listings,
+  };
 };

--- a/client/src/pages/TeamPage.js
+++ b/client/src/pages/TeamPage.js
@@ -35,10 +35,10 @@ export const TeamPage = () => {
   const handleInvite = async (e) => {
     e.preventDefault();
     try {
-      const userId = await axios.get(`/api/users/usernames/${friendRequest}`);
+      const userResponse = await axios.get(`/api/users/${friendRequest}`);
       try {
         await axios.post(`/api/teams/${id}/teammates`, {
-          userId: userId.data,
+          userId: userResponse.data.user.id,
           status: "invited",
         });
         setIsSuccess(true);

--- a/client/src/pages/TeamsPage.js
+++ b/client/src/pages/TeamsPage.js
@@ -69,16 +69,11 @@ export const TeamsPage = () => {
 };
 
 export const teamsLoader = async ({ request, params }) => {
-  const { data } = await axios.get("/api/session");
-  if (data) {
-    const { username } = data;
-    const [userResponse, allTeamsResponse] = await Promise.all([
-      axios.get(`/api/users/${username}`),
-      axios.get("/api/teams"),
-    ]);
-    const teams = allTeamsResponse.data;
-    const { teams: userTeams } = userResponse.data;
-    return { teams, userTeams };
-  }
-  return null;
+  const [userResponse, allTeamsResponse] = await Promise.all([
+    axios.get("/api/session/user"),
+    axios.get("/api/teams"),
+  ]);
+  const teams = allTeamsResponse.data;
+  const { teams: userTeams } = userResponse.data;
+  return { teams, userTeams };
 };

--- a/client/src/pages/UserPage.js
+++ b/client/src/pages/UserPage.js
@@ -12,7 +12,7 @@ export const UserPage = () => {
   const { authedUser } = useAuth();
 
   const { readme, username } = user;
-  const isSessionedUserPage = authedUser.id === user.id;
+  const isSessionedUserPage = authedUser.username === user.username;
 
   return (
     <>

--- a/client/src/pages/UserSettingsPage.js
+++ b/client/src/pages/UserSettingsPage.js
@@ -30,7 +30,7 @@ export const UserSettingsPage = () => {
       readme,
     };
 
-    await axios.patch(`/api/users/${user.id}`, updates);
+    await axios.patch("/api/session/user", updates);
     navigate(`/${user.username}`);
   };
 

--- a/client/src/pages/UserSettingsPage.js
+++ b/client/src/pages/UserSettingsPage.js
@@ -170,8 +170,7 @@ export const UserSettingsPage = () => {
 };
 
 export const userSettingsLoader = async ({ request, params }) => {
-  const { username } = params;
-  const userResponse = await axios.get(`/api/users/${username}`);
+  const userResponse = await axios.get("/api/session/user");
   const { user } = userResponse.data;
 
   return { user };

--- a/server/controllers/listingsController.js
+++ b/server/controllers/listingsController.js
@@ -57,9 +57,7 @@ const addFavorite = async (req, res, next) => {
 const deleteFavorite = async (req, res, next) => {
   try {
     const { id } = req.user;
-    console.log(id);
     const { listingId } = req.params;
-    console.log(listingId);
     const deletedFavorite = await Listing.deleteFavorite(id, listingId);
     if (!deletedFavorite) {
       return res.status(404).json({

--- a/server/controllers/listingsController.js
+++ b/server/controllers/listingsController.js
@@ -42,9 +42,41 @@ const deleteListing = async (req, res, next) => {
   }
 };
 
+const addFavorite = async (req, res, next) => {
+  try {
+    const { id } = req.user;
+    const { listingId } = req.params;
+    const addedFavorite = await Listing.addFavorite(id, listingId);
+
+    res.status(200).json(addedFavorite);
+  } catch (error) {
+    next(error);
+  }
+};
+
+const deleteFavorite = async (req, res, next) => {
+  try {
+    const { id } = req.user;
+    console.log(id);
+    const { listingId } = req.params;
+    console.log(listingId);
+    const deletedFavorite = await Listing.deleteFavorite(id, listingId);
+    if (!deletedFavorite) {
+      return res.status(404).json({
+        message: `Favorite not found`,
+      });
+    }
+    res.status(200).json(deletedFavorite);
+  } catch (error) {
+    next(error);
+  }
+};
+
 module.exports = {
   createListing,
   getSingleListing,
   deleteListing,
   updateListing,
+  addFavorite,
+  deleteFavorite,
 };

--- a/server/controllers/sessionController.js
+++ b/server/controllers/sessionController.js
@@ -27,6 +27,41 @@ const getSessionUser = async (req, res, next) => {
   }
 };
 
+const updateSessionUser = async (req, res, next) => {
+  try {
+    const { id } = req.user;
+    const updates = req.body;
+
+    const updatedUser = await User.updateUser(id, updates);
+    if (!updatedUser) {
+      return res.status(404).json({
+        message: `User with id ${id} not found.`,
+      });
+    }
+    res.status(200).json(updatedUser);
+  } catch (error) {
+    next(error);
+  }
+};
+
+const deleteSessionUser = async (req, res, next) => {
+  try {
+    const { id } = req.user;
+    const deletedUser = await User.deleteUser(id);
+    if (!deletedUser) {
+      return res.status(404).json({
+        message: `User with id ${id} not found.`,
+      });
+    }
+    res.status(200).json({
+      message: `User with id ${id} has been deleted.`,
+      deletedUser,
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
 const loginUser = async (req, res, next) => {
   const { credential, password } = req.body;
 
@@ -53,4 +88,6 @@ module.exports = {
   logoutUser,
   getSession,
   getSessionUser,
+  updateSessionUser,
+  deleteSessionUser,
 };

--- a/server/controllers/sessionController.js
+++ b/server/controllers/sessionController.js
@@ -17,7 +17,7 @@ const getSessionUser = async (req, res, next) => {
     const favorites = await User.getUserFavorites(id);
     const teams = await User.getUserTeams(id);
     const teammates = await User.getUserTeammates(id);
-    const recommendedTeams = await Team.getRecommendedTeams(id);
+    const recommendedTeams = await User.getRecommendedTeams(id);
 
     res
       .status(200)

--- a/server/controllers/sessionController.js
+++ b/server/controllers/sessionController.js
@@ -13,7 +13,7 @@ const getSession = async (req, res) => {
 const getSessionUser = async (req, res, next) => {
   const { id } = req.user;
   try {
-    const user = await User.getSingleUser(id);
+    const user = await User.getSessionUser(id);
     const favorites = await User.getUserFavorites(id);
     const teams = await User.getUserTeams(id);
     const teammates = await User.getUserTeammates(id);

--- a/server/controllers/sessionController.js
+++ b/server/controllers/sessionController.js
@@ -1,7 +1,5 @@
 const { setTokenCookie } = require("../utils/auth");
-
 const User = require("../models/User");
-const Team = require("../models/Team");
 
 const getSession = async (req, res) => {
   const { user } = req;

--- a/server/controllers/sessionController.js
+++ b/server/controllers/sessionController.js
@@ -1,12 +1,30 @@
 const { setTokenCookie } = require("../utils/auth");
 
 const User = require("../models/User");
+const Team = require("../models/Team");
 
 const getSession = async (req, res) => {
   const { user } = req;
   if (user) {
     return res.status(200).json(user);
   } else return res.status(200).json(null);
+};
+
+const getSessionUser = async (req, res, next) => {
+  const { id } = req.user;
+  try {
+    const user = await User.getSingleUser(id);
+    const favorites = await User.getUserFavorites(id);
+    const teams = await User.getUserTeams(id);
+    const teammates = await User.getUserTeammates(id);
+    const recommendedTeams = await Team.getRecommendedTeams(id);
+
+    res
+      .status(200)
+      .json({ user, favorites, teams, teammates, recommendedTeams });
+  } catch (error) {
+    next(error);
+  }
 };
 
 const loginUser = async (req, res, next) => {
@@ -34,4 +52,5 @@ module.exports = {
   loginUser,
   logoutUser,
   getSession,
+  getSessionUser,
 };

--- a/server/controllers/teamsController.js
+++ b/server/controllers/teamsController.js
@@ -66,16 +66,6 @@ const getAllTeamListings = async (req, res, next) => {
   }
 };
 
-const getRecommendedTeams = async (req, res, next) => {
-  try {
-    const { userId } = req.params;
-    const recommendedTeams = await Team.getRecommendedTeams(userId);
-    res.status(200).json(recommendedTeams);
-  } catch (error) {
-    next(error);
-  }
-};
-
 const updateTeammateStatus = async (req, res, next) => {
   //TODO: CHECK IF CALLING USER HAS PRIVILEGES
   try {
@@ -142,7 +132,6 @@ module.exports = {
   addUserToTeam,
   getAllTeammates,
   getAllTeamListings,
-  getRecommendedTeams,
   createTeam,
   updateTeammateStatus,
   deleteTeammate,

--- a/server/controllers/usersController.js
+++ b/server/controllers/usersController.js
@@ -30,12 +30,11 @@ const getUser = async (req, res, next) => {
   try {
     const { username } = req.params;
     const userId = await User.getIdByUsername(username);
-    const user = await User.getSingleUser(userId);
-    const favorites = await User.getUserFavorites(userId);
+    const user = await User.getPublicUser(userId);
     const teams = await User.getUserTeams(userId);
     const teammates = await User.getUserTeammates(userId);
 
-    res.status(200).json({ user, favorites, teams, teammates });
+    res.status(200).json({ user, teams, teammates });
   } catch (error) {
     next(error);
   }

--- a/server/controllers/usersController.js
+++ b/server/controllers/usersController.js
@@ -40,38 +40,8 @@ const getUser = async (req, res, next) => {
   }
 };
 
-const addUserFavorite = async (req, res, next) => {
-  try {
-    const { userId } = req.params;
-    const { listingId } = req.body;
-    const addedFavorite = await User.addUserFavorite(userId, listingId);
-
-    res.status(200).json(addedFavorite);
-  } catch (error) {
-    next(error);
-  }
-};
-
-const deleteUserFavorite = async (req, res, next) => {
-  try {
-    const { userId } = req.params;
-    const { listingId } = req.body;
-    const deletedFavorite = await User.deleteUserFavorite(userId, listingId);
-    if (!deletedFavorite) {
-      return res.status(404).json({
-        message: `Favorite not found`,
-      });
-    }
-    res.status(200).json(deletedFavorite);
-  } catch (error) {
-    next(error);
-  }
-};
-
 module.exports = {
   createUser,
   getAllUsers,
   getUser,
-  addUserFavorite,
-  deleteUserFavorite,
 };

--- a/server/controllers/usersController.js
+++ b/server/controllers/usersController.js
@@ -26,13 +26,12 @@ const getAllUsers = async (req, res, next) => {
   }
 };
 
-const getUser = async (req, res, next) => {
+const getPublicUser = async (req, res, next) => {
   try {
     const { username } = req.params;
-    const userId = await User.getIdByUsername(username);
-    const user = await User.getPublicUser(userId);
-    const teams = await User.getUserTeams(userId);
-    const teammates = await User.getUserTeammates(userId);
+    const { id, ...user } = await User.getPublicUser(username);
+    const teams = await User.getUserTeams(id);
+    const teammates = await User.getUserTeammates(id);
 
     res.status(200).json({ user, teams, teammates });
   } catch (error) {
@@ -43,5 +42,5 @@ const getUser = async (req, res, next) => {
 module.exports = {
   createUser,
   getAllUsers,
-  getUser,
+  getPublicUser,
 };

--- a/server/controllers/usersController.js
+++ b/server/controllers/usersController.js
@@ -68,47 +68,10 @@ const deleteUserFavorite = async (req, res, next) => {
   }
 };
 
-const deleteUser = async (req, res, next) => {
-  try {
-    const { userId } = req.params;
-    const deletedUser = await User.deleteUser(userId);
-    if (!deletedUser) {
-      return res.status(404).json({
-        message: `User with id ${userId} not found.`,
-      });
-    }
-    res.status(200).json({
-      message: `User with id ${userId} has been deleted.`,
-      deletedUser,
-    });
-  } catch (error) {
-    next(error);
-  }
-};
-
-const updateUser = async (req, res, next) => {
-  try {
-    const { userId } = req.params;
-    const updates = req.body;
-
-    const updatedUser = await User.updateUser(userId, updates);
-    if (!updatedUser) {
-      return res.status(404).json({
-        message: `User with id ${userId} not found.`,
-      });
-    }
-    res.status(200).json(updatedUser);
-  } catch (error) {
-    next(error);
-  }
-};
-
 module.exports = {
   createUser,
   getAllUsers,
   getUser,
   addUserFavorite,
   deleteUserFavorite,
-  deleteUser,
-  updateUser,
 };

--- a/server/models/Listing.js
+++ b/server/models/Listing.js
@@ -59,10 +59,39 @@ const deleteListing = async (listingId) => {
     throw new Error("Database Error: " + error.message);
   }
 };
+const addFavorite = async (userId, listingId) => {
+  try {
+    const [addedFavorite] = await knex("users_favorites")
+      .insert({
+        userId,
+        listingId,
+      })
+      .returning(["user_id", "listing_id"]);
+
+    return addedFavorite;
+  } catch (error) {
+    throw new Error("Database Error: " + error.message);
+  }
+};
+
+const deleteFavorite = async (userId, listingId) => {
+  try {
+    const [deletedFavorite] = await knex("users_favorites")
+      .where("user_id", userId)
+      .andWhere("listing_id", listingId)
+      .del()
+      .returning("*");
+    return deletedFavorite;
+  } catch (error) {
+    throw new Error("Database Error: " + error.message);
+  }
+};
 
 module.exports = {
   createListing,
   getSingleListing,
   deleteListing,
   updateListing,
+  addFavorite,
+  deleteFavorite,
 };

--- a/server/models/Team.js
+++ b/server/models/Team.js
@@ -83,54 +83,6 @@ const getAllTeamListings = async (teamId) => {
   }
 };
 
-const getRecommendedTeams = async (userId) => {
-  try {
-    // Retrieve the list of teams that the user is currently a member of
-    const userTeams = (
-      await knex("users_teams")
-        .where("user_id", userId)
-        .join("teams", "users_teams.team_id", "=", "teams.id")
-        .select("teams.id")
-    ).map((team) => team.id);
-
-    // Retrieve the list of teams that those remaining users are members of
-    const recommendedTeams = await knex("users_teams")
-      .join("teams", "users_teams.team_id", "=", "teams.id")
-      .select("teams.id", "teams.name", "teams.job_field", "teams.description")
-      .whereIn(
-        // includes teams that are asssociated with all of user's teammates
-        "user_id",
-        knex("users_teams") // list of userIds that matches the following criteria ------------------------------}
-          .join("users", "users_teams.user_id", "=", "users.id") //                                              }
-          .select("users.id") //                                                                                 }
-          .whereIn("team_id", userTeams) // only include userIds which are associated with the user's teams      }
-      ) // ------------------------------------------------------------------------------------------------------}
-      .whereNotIn("team_id", userTeams) // but excludes teams the user is already in
-      .distinct();
-
-    // Retrieve the list of teams that have the same job field as the current user
-    //Below needs to be done a different way, let user select a job field on account creation or profile settings?
-
-    // const userJobField = userTeams[0]?.job_field;
-    // if (userJobField) {
-    //   const jobFieldTeams = await knex("teams")
-    //     .where("job_field", userJobField)
-    //     .andWhereNot(
-    //       "id",
-    //       userTeams.map((team) => team.id)
-    //     )
-    //     .select("id", "name", "job_field", "description");
-
-    //   recommendedTeams.push(...jobFieldTeams);
-    // }
-    // console.log(recommendedTeams, recommendedTeams.length);
-
-    return recommendedTeams;
-  } catch (error) {
-    throw new Error("Database Error: " + error.message);
-  }
-};
-
 const updateTeammateStatus = async (userId, teamId, status) => {
   const approvedStatuses = ["owner", "admin", "member", "invited", "requested"];
   try {
@@ -195,7 +147,6 @@ module.exports = {
   getSingleTeam,
   getAllTeammates,
   getAllTeamListings,
-  getRecommendedTeams,
   createTeam,
   addUserToTeam,
   updateTeammateStatus,

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -106,34 +106,6 @@ const getUserFavorites = async (userId) => {
   }
 };
 
-const addUserFavorite = async (userId, listingId) => {
-  try {
-    const [addedFavorite] = await knex("users_favorites")
-      .insert({
-        userId,
-        listingId,
-      })
-      .returning(["user_id", "listing_id"]);
-
-    return addedFavorite;
-  } catch (error) {
-    throw new Error("Database Error: " + error.message);
-  }
-};
-
-const deleteUserFavorite = async (userId, listingId) => {
-  try {
-    const [deletedFavorite] = await knex("users_favorites")
-      .where("user_id", userId)
-      .andWhere("listing_id", listingId)
-      .del()
-      .returning("*");
-    return deletedFavorite;
-  } catch (error) {
-    throw new Error("Database Error: " + error.message);
-  }
-};
-
 const getUserTeams = async (userId) => {
   try {
     const teams = await knex("users_teams")
@@ -258,8 +230,6 @@ module.exports = {
   getPublicUser,
   getSessionUser,
   getUserFavorites,
-  addUserFavorite,
-  deleteUserFavorite,
   getUserTeams,
   getUserTeammates,
   deleteUser,

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -71,6 +71,16 @@ const getPublicUser = async (userId) => {
   }
 };
 
+const getSessionUser = async (userId) => {
+  try {
+    const data = await knex("users").select("*").where("id", userId).first();
+    const { hashedPassword, ...user } = data;
+    return user;
+  } catch (error) {
+    throw new Error("Database Error: " + error.message);
+  }
+};
+
 const getSingleUserByUsername = async (username) => {
   try {
     const data = await knex("users")
@@ -198,6 +208,7 @@ module.exports = {
   createUser,
   getAllUsers,
   getPublicUser,
+  getSessionUser,
   getUserFavorites,
   addUserFavorite,
   deleteUserFavorite,

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -171,6 +171,54 @@ const getUserTeammates = async (userId) => {
   }
 };
 
+const getRecommendedTeams = async (userId) => {
+  try {
+    // Retrieve the list of teams that the user is currently a member of
+    const userTeams = (
+      await knex("users_teams")
+        .where("user_id", userId)
+        .join("teams", "users_teams.team_id", "=", "teams.id")
+        .select("teams.id")
+    ).map((team) => team.id);
+
+    // Retrieve the list of teams that those remaining users are members of
+    const recommendedTeams = await knex("users_teams")
+      .join("teams", "users_teams.team_id", "=", "teams.id")
+      .select("teams.id", "teams.name", "teams.job_field", "teams.description")
+      .whereIn(
+        // includes teams that are asssociated with all of user's teammates
+        "user_id",
+        knex("users_teams") // list of userIds that matches the following criteria ------------------------------}
+          .join("users", "users_teams.user_id", "=", "users.id") //                                              }
+          .select("users.id") //                                                                                 }
+          .whereIn("team_id", userTeams) // only include userIds which are associated with the user's teams      }
+      ) // ------------------------------------------------------------------------------------------------------}
+      .whereNotIn("team_id", userTeams) // but excludes teams the user is already in
+      .distinct();
+
+    // Retrieve the list of teams that have the same job field as the current user
+    //Below needs to be done a different way, let user select a job field on account creation or profile settings?
+
+    // const userJobField = userTeams[0]?.job_field;
+    // if (userJobField) {
+    //   const jobFieldTeams = await knex("teams")
+    //     .where("job_field", userJobField)
+    //     .andWhereNot(
+    //       "id",
+    //       userTeams.map((team) => team.id)
+    //     )
+    //     .select("id", "name", "job_field", "description");
+
+    //   recommendedTeams.push(...jobFieldTeams);
+    // }
+    // console.log(recommendedTeams, recommendedTeams.length);
+
+    return recommendedTeams;
+  } catch (error) {
+    throw new Error("Database Error: " + error.message);
+  }
+};
+
 const deleteUser = async (userId) => {
   try {
     const [deletedUser] = await knex("users")
@@ -220,4 +268,5 @@ module.exports = {
   getSingleUserByUsername,
   getSession,
   getIdByUsername,
+  getRecommendedTeams,
 };

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -37,7 +37,7 @@ const createUser = async (user) => {
   }
 };
 
-const getSessionedUser = async (userId) => {
+const getSession = async (userId) => {
   try {
     const user = await knex("users")
       .select("id", "username", "email")
@@ -58,11 +58,14 @@ const getAllUsers = async () => {
   }
 };
 
-const getSingleUser = async (userId) => {
+const getPublicUser = async (userId) => {
   try {
     const data = await knex("users").select("*").where("id", userId).first();
-    const { hashedPassword, ...user } = data;
-    return user;
+    const { hashedPassword, isEmailPublic, email, id, ...user } = data;
+    if (!isEmailPublic) {
+      return { isEmailPublic, ...user };
+    }
+    return { isEmailPublic, email, ...user };
   } catch (error) {
     throw new Error("Database Error: " + error.message);
   }
@@ -194,7 +197,7 @@ const getIdByUsername = async (username) => {
 module.exports = {
   createUser,
   getAllUsers,
-  getSingleUser,
+  getPublicUser,
   getUserFavorites,
   addUserFavorite,
   deleteUserFavorite,
@@ -204,6 +207,6 @@ module.exports = {
   updateUser,
   loginUser,
   getSingleUserByUsername,
-  getSessionedUser,
+  getSession,
   getIdByUsername,
 };

--- a/server/routes/comments.js
+++ b/server/routes/comments.js
@@ -7,11 +7,6 @@ const {
   updateComment,
 } = require("../controllers/commentsController");
 
-/* GET experiences. */
-router.get("/", function (req, res, next) {
-  res.json({ users: ["commentOne", "commentTwo", "commentThree"] });
-});
-
 router.post("/", addComment);
 router.get("/:listingId", getListingComments);
 router.delete("/:commentId", deleteComment);

--- a/server/routes/listings.js
+++ b/server/routes/listings.js
@@ -5,11 +5,15 @@ const {
   getSingleListing,
   deleteListing,
   updateListing,
+  addFavorite,
+  deleteFavorite,
 } = require("../controllers/listingsController");
 
 router.post("/", createListing);
 router.get("/:listingId", getSingleListing);
 router.delete("/:listingId", deleteListing);
 router.patch("/:listingId", updateListing);
+router.post("/:listingId/favorites", addFavorite);
+router.delete("/:listingId/favorites", deleteFavorite);
 
 module.exports = router;

--- a/server/routes/session.js
+++ b/server/routes/session.js
@@ -7,16 +7,15 @@ const {
   logoutUser,
   getSession,
   getSessionUser,
+  updateSessionUser,
+  deleteSessionUser,
 } = require("../controllers/sessionController");
 
 router.get("/", getSession);
-
 router.post("/", validateLogin, loginUser);
 router.delete("/", logoutUser);
 router.get("/user", getSessionUser);
-
-// router.post("/user", createUser)
-// router.patch("/user", updateUser)   *needs a check against sessionedUser
-// router.delete("/user", deleteUser)   *needs a check against sessionedUser
+router.patch("/user", updateSessionUser);
+router.delete("/user", deleteSessionUser);
 
 module.exports = router;

--- a/server/routes/session.js
+++ b/server/routes/session.js
@@ -9,7 +9,6 @@ const {
   getSessionUser,
 } = require("../controllers/sessionController");
 
-// getSession may be gone, this data will come with the potential /user route below
 router.get("/", getSession);
 
 router.post("/", validateLogin, loginUser);

--- a/server/routes/session.js
+++ b/server/routes/session.js
@@ -6,6 +6,7 @@ const {
   loginUser,
   logoutUser,
   getSession,
+  getSessionUser,
 } = require("../controllers/sessionController");
 
 // getSession may be gone, this data will come with the potential /user route below
@@ -13,8 +14,8 @@ router.get("/", getSession);
 
 router.post("/", validateLogin, loginUser);
 router.delete("/", logoutUser);
+router.get("/user", getSessionUser);
 
-// router.get("/user", getUser)     *public and private data
 // router.post("/user", createUser)
 // router.patch("/user", updateUser)   *needs a check against sessionedUser
 // router.delete("/user", deleteUser)   *needs a check against sessionedUser

--- a/server/routes/teams.js
+++ b/server/routes/teams.js
@@ -8,7 +8,6 @@ const {
   addUserToTeam,
   getAllTeammates,
   getAllTeamListings,
-  getRecommendedTeams,
   updateTeammateStatus,
   deleteTeammate,
   updateTeam,
@@ -17,7 +16,6 @@ const {
 
 router.get("/", getAllTeams);
 router.post("/", createTeam);
-router.get("/recommended/:userId", getRecommendedTeams);
 router.get("/:teamId", getSingleTeam);
 router.patch("/:teamId", updateTeam);
 router.delete("/:teamId", deleteTeam);

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -5,17 +5,11 @@ const { validateSignup } = require("../utils/validation");
 const {
   getAllUsers,
   getUser,
-  addUserFavorite,
-  deleteUserFavorite,
   createUser,
 } = require("../controllers/usersController");
 
 router.get("/", getAllUsers);
 router.post("/", validateSignup, createUser);
 router.get("/:username", getUser);
-
-// These also need to find a new home, these are always private
-router.post("/:userId/favorites", addUserFavorite);
-router.delete("/:userId/favorites", deleteUserFavorite);
 
 module.exports = router;

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -8,19 +8,11 @@ const {
   addUserFavorite,
   deleteUserFavorite,
   createUser,
-  deleteUser,
-  updateUser,
 } = require("../controllers/usersController");
 
 router.get("/", getAllUsers);
 router.post("/", validateSignup, createUser);
-
-// This needs to be modified to only return public data
 router.get("/:username", getUser);
-
-// These two will move to session, needs to be authorized against session user
-router.patch("/:userId", updateUser);
-router.delete("/:userId", deleteUser);
 
 // These also need to find a new home, these are always private
 router.post("/:userId/favorites", addUserFavorite);

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -4,12 +4,12 @@ const router = express.Router();
 const { validateSignup } = require("../utils/validation");
 const {
   getAllUsers,
-  getUser,
+  getPublicUser,
   createUser,
 } = require("../controllers/usersController");
 
 router.get("/", getAllUsers);
 router.post("/", validateSignup, createUser);
-router.get("/:username", getUser);
+router.get("/:username", getPublicUser);
 
 module.exports = router;

--- a/server/utils/auth.js
+++ b/server/utils/auth.js
@@ -35,7 +35,7 @@ const restoreUser = (req, res, next) => {
 
     try {
       const { id } = jwtPayload.data;
-      req.user = await User.getSessionedUser(id);
+      req.user = await User.getSession(id);
     } catch (e) {
       res.clearCookie("token");
       return next();


### PR DESCRIPTION
- Creates getSessionUser api and makes changes to relevant pages in the client
- Differentiates getSessionUser and getPublicUser in User model
- Moves deleteUser and updateUser to session API (only a sessioned user can delete/update their own account)
- Moves favorites API to listings router
- Additional minor changes and removal of console.logs, comments, and unused code