### PR TITLE
Condense links

### DIFF
--- a/client/src/components/AllTeams.js
+++ b/client/src/components/AllTeams.js
@@ -60,7 +60,7 @@ const AllTeams = ({ isFilterModalShowing, handleFilterModal }) => {
               sortedTeams.map((team, index) => (
                 <NavLink
                   to={`/teams/${team.id}`}
-                  className="no-underline text-black bg-white p-2.5 hover:bg-blue-200 border-b border-slate-200 inline-block overflow-ellipsis overflow-hidden whitespace-nowrap"
+                  className="no-underline text-black bg-white p-2.5 hover:bg-blue-200 border-b border-slate-200 inline-block truncate"
                   key={`${team.name}-${index}`}
                 >
                   <span className="font-semibold">{team.name} / </span>

--- a/client/src/components/ExternalLink.js
+++ b/client/src/components/ExternalLink.js
@@ -1,0 +1,23 @@
+const ExternalLink = () => {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M17 13.5v6H5v-12h6m3-3h6v6m0-6-9 9"
+        class="icon_svg-stroke"
+        stroke="#666"
+        stroke-width="1.5"
+        fill="none"
+        fill-rule="evenodd"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      ></path>
+    </svg>
+  );
+};
+
+export default ExternalLink;

--- a/client/src/components/ExternalLink.js
+++ b/client/src/components/ExternalLink.js
@@ -1,22 +1,24 @@
-const ExternalLink = () => {
+const ExternalLink = ({ dimensions }) => {
   return (
-    <svg
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M17 13.5v6H5v-12h6m3-3h6v6m0-6-9 9"
-        class="icon_svg-stroke"
-        stroke="#666"
-        stroke-width="1.5"
-        fill="none"
-        fill-rule="evenodd"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-      ></path>
-    </svg>
+    <div>
+      <svg
+        width={dimensions}
+        height={dimensions}
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M17 13.5v6H5v-12h6m3-3h6v6m0-6-9 9"
+          class="icon_svg-stroke"
+          stroke="#666"
+          stroke-width="1.5"
+          fill="none"
+          fill-rule="evenodd"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        ></path>
+      </svg>
+    </div>
   );
 };
 

--- a/client/src/components/FilterByInterests.js
+++ b/client/src/components/FilterByInterests.js
@@ -31,7 +31,7 @@ const FilterByInterests = ({ filterBy, setFilterBy }) => {
                 ? "bg-highlightblue"
                 : "bg-slate-100"
             } py-1 px-2 rounded-full w-fit hover:bg-highlightblue hover:cursor-pointer
-            overflow-hidden overflow-ellipsis whitespace-nowrap`}
+            truncate`}
             onClick={() => handleSelectFilter(jf)}
           >
             {jf.jobField}

--- a/client/src/components/ListingDetails.js
+++ b/client/src/components/ListingDetails.js
@@ -12,6 +12,7 @@ import { basicModules } from "../utils/quillModules";
 import "react-quill/dist/quill.snow.css";
 import useOnClickOutside from "../hooks/useOnClickOutside";
 import ExternalLink from "../components/ExternalLink";
+import trimUrl from "../utils/trimUrl";
 
 const ListingDetails = ({ tabs, handleModal }) => {
   const { listing } = useLoaderData();
@@ -154,7 +155,7 @@ const ListingDetails = ({ tabs, handleModal }) => {
             rel="noreferrer"
             href={`${tempListing.jobLink}`}
           >
-            <div className="truncate">{tempListing.jobLink}</div>
+            <div className="truncate">{trimUrl(tempListing.jobLink)}</div>
             <ExternalLink dimensions="24" />
           </a>
         )}

--- a/client/src/components/ListingDetails.js
+++ b/client/src/components/ListingDetails.js
@@ -11,6 +11,7 @@ import ReactQuill from "react-quill";
 import { basicModules } from "../utils/quillModules";
 import "react-quill/dist/quill.snow.css";
 import useOnClickOutside from "../hooks/useOnClickOutside";
+import ExternalLink from "../components/ExternalLink";
 
 const ListingDetails = ({ tabs, handleModal }) => {
   const { listing } = useLoaderData();
@@ -135,7 +136,7 @@ const ListingDetails = ({ tabs, handleModal }) => {
         </div>
       </div>
       <div
-        className="w-full sm:w-2/5 sm:min-w-[300px]"
+        className="w-full sm:w-3/5 sm:min-w-[300px]"
         {...(showEditInput === "jobLink" ? { ref: editRef } : {})}
       >
         <h3 className="font-bold text-slate-400">Link to Apply</h3>
@@ -148,12 +149,13 @@ const ListingDetails = ({ tabs, handleModal }) => {
           />
         ) : (
           <a
-            className="no-underline text-black px-1 border-2 border-white hover:underline"
+            className="flex no-underline px-1 border-2 border-white hover:underline truncate"
             target="_blank"
             rel="noreferrer"
             href={`${tempListing.jobLink}`}
           >
-            {tempListing.jobLink}
+            <div className="truncate">{tempListing.jobLink}</div>
+            <ExternalLink dimensions="24" />
           </a>
         )}
         <div

--- a/client/src/components/ListingExperiences.js
+++ b/client/src/components/ListingExperiences.js
@@ -41,7 +41,7 @@ const ListingExperiences = ({ tabs, setIsCreateExpModalShowing }) => {
               key={experience.id}
             >
               <div className="flex items-center overflow-hidden">
-                <p className="text-sm sm:text-base font-bold overflow-hidden overflow-ellipsis whitespace-nowrap">
+                <p className="text-sm sm:text-base font-bold truncate">
                   {experience.title}
                 </p>
                 <p className="sm:text-base font-bold mx-1 sm:mx-2">/</p>

--- a/client/src/components/ListingTabs.js
+++ b/client/src/components/ListingTabs.js
@@ -2,7 +2,7 @@ const ListingTabs = ({ tabs, setTabs }) => {
   return (
     <div className="flex gap-3 overflow-hidden text-base text-center justify-center sm:mr-10 sm:justify-start sm:text-lg">
       <button
-        className={`pb-1 w-28 overflow-hidden overflow-ellipsis whitespace-nowrap ${
+        className={`pb-1 w-28 overflow-hidden truncate ${
           tabs === "listing"
             ? "border-b-[3px] text-bluegray border-bluegray font-bold"
             : "border-b text-slate-400 border-slate-400"
@@ -12,7 +12,7 @@ const ListingTabs = ({ tabs, setTabs }) => {
         Listing
       </button>
       <button
-        className={`pb-1 w-28 overflow-hidden overflow-ellipsis whitespace-nowrap ${
+        className={`pb-1 w-28 overflow-hidden truncate ${
           tabs === "experiences"
             ? "border-b-[3px] text-bluegray border-bluegray font-bold"
             : "border-b text-slate-400 border-slate-400"
@@ -22,7 +22,7 @@ const ListingTabs = ({ tabs, setTabs }) => {
         Experiences
       </button>
       <button
-        className={`pb-1 w-28 overflow-hidden overflow-ellipsis whitespace-nowrap ${
+        className={`pb-1 w-28 overflow-hidden truncate ${
           tabs === "comments"
             ? "border-b-[3px] text-bluegray border-bluegray font-bold"
             : "border-b text-slate-400 border-slate-400"

--- a/client/src/components/RecentActivity.js
+++ b/client/src/components/RecentActivity.js
@@ -74,7 +74,7 @@ const RecentActivity = ({ activity, index }) => {
       key={index + activity.username}
       className="flex flex-row items-center gap-2 border-b bg-white p-2.5 rounded-md hover:bg-highlightblue"
     >
-      <p className="w-full text-sm overflow-hidden overflow-ellipsis whitespace-nowrap sm:text-base">
+      <p className="w-full text-sm truncate sm:text-base">
         <NavLink className="font-semibold text-blue-600" to={`/${username}`}>
           {username}
         </NavLink>{" "}

--- a/client/src/components/RecommendedTeams.js
+++ b/client/src/components/RecommendedTeams.js
@@ -30,7 +30,7 @@ const RecommendedTeams = () => {
             <NavLink
               to={`/teams/${team.id}`}
               className="no-underline text-black bg-white p-2.5 hover:bg-blue-200 border-b border-slate-200 
-            inline-block overflow-ellipsis overflow-hidden whitespace-nowrap"
+            inline-block truncate"
               key={team.id}
             >
               <span className="font-semibold">{team.name} / </span>

--- a/client/src/components/TeamListings.js
+++ b/client/src/components/TeamListings.js
@@ -36,7 +36,7 @@ const TeamListings = ({ handleModal }) => {
                     {listing.companyName}
                   </p>
                   <p className="font-bold mx-1 sm:text-lg sm:mx-2">/</p>
-                  <p className="text-sm overflow-hidden overflow-ellipsis whitespace-nowrap sm:text-base">
+                  <p className="text-sm truncate sm:text-base">
                     {listing.jobTitle}
                   </p>
                 </div>

--- a/client/src/components/UserInfo.js
+++ b/client/src/components/UserInfo.js
@@ -1,5 +1,7 @@
 import NullInfo from "./NullInfo";
 import formatJoinDate from "../utils/formatJoinDate";
+import ExternalLink from "../components/ExternalLink";
+import trimUrl from "../utils/trimUrl";
 
 const UserInfo = ({ user }) => {
   const { dateJoined, email, firstName, github, linkedin, isEmailPublic } =
@@ -22,17 +24,31 @@ const UserInfo = ({ user }) => {
         <span className="text-sm font-bold">joined / </span>
         <span>{formattedDate}</span>
       </div>
-      <div className={listItemStyle}>
-        <span className="text-sm font-bold">linkedIn / </span>
-        {linkedin ? <span>{linkedin}</span> : <NullInfo />}
+      <div className={`${listItemStyle} flex items-center gap-1`}>
+        <p className="text-sm font-bold whitespace-nowrap">linkedIn / </p>
+        {linkedin ? (
+          <a className="flex overflow-hidden" href={linkedin}>
+            <div className="truncate">{trimUrl(linkedin)}</div>
+            <ExternalLink dimensions="24" />
+          </a>
+        ) : (
+          <NullInfo />
+        )}
       </div>
-      <div className={listItemStyle}>
-        <span className="text-sm font-bold">github / </span>
-        {github ? <span>{github}</span> : <NullInfo />}
+      <div className={`${listItemStyle} flex items-center gap-1`}>
+        <span className="text-sm font-bold whitespace-nowrap">github / </span>
+        {github ? (
+          <a className="flex overflow-hidden" href={github}>
+            <div className="truncate">{trimUrl(github)}</div>
+            <ExternalLink dimensions="24" />
+          </a>
+        ) : (
+          <NullInfo />
+        )}
       </div>
       {isEmailPublic && (
-        <div className={listItemStyle}>
-          <span>{email}</span>
+        <div className={`${listItemStyle} overflow-hidden`}>
+          <p className="truncate">{email}</p>
         </div>
       )}
     </>

--- a/client/src/components/UserInfo.js
+++ b/client/src/components/UserInfo.js
@@ -27,7 +27,12 @@ const UserInfo = ({ user }) => {
       <div className={`${listItemStyle} flex items-center gap-1`}>
         <p className="text-sm font-bold whitespace-nowrap">linkedIn / </p>
         {linkedin ? (
-          <a className="flex overflow-hidden" href={linkedin}>
+          <a
+            target="_blank"
+            rel="noreferrer"
+            className="flex overflow-hidden"
+            href={linkedin}
+          >
             <div className="truncate">{trimUrl(linkedin)}</div>
             <ExternalLink dimensions="24" />
           </a>
@@ -38,7 +43,12 @@ const UserInfo = ({ user }) => {
       <div className={`${listItemStyle} flex items-center gap-1`}>
         <span className="text-sm font-bold whitespace-nowrap">github / </span>
         {github ? (
-          <a className="flex overflow-hidden" href={github}>
+          <a
+            target="_blank"
+            rel="noreferrer"
+            className="flex overflow-hidden"
+            href={github}
+          >
             <div className="truncate">{trimUrl(github)}</div>
             <ExternalLink dimensions="24" />
           </a>

--- a/client/src/components/UserTeammatesList.js
+++ b/client/src/components/UserTeammatesList.js
@@ -35,10 +35,7 @@ const UserTeammatesList = () => {
             key={`${teammate.id}-${index}`}
           >
             <div className="bg-slate-900 rounded-full w-6 h-6 mr-4" />
-            <p className="overflow-hidden overflow-ellipsis whitespace-nowrap">
-              {" "}
-              {teammate.username}
-            </p>
+            <p className="truncate"> {teammate.username}</p>
           </NavLink>
         ))}
       </ul>

--- a/client/src/components/UserTeamsList.js
+++ b/client/src/components/UserTeamsList.js
@@ -31,7 +31,7 @@ const UserTeamsList = ({ heading = "TEAMS" }) => {
           userTeams.map((team) => (
             <NavLink
               to={`/teams/${team.id}`}
-              className="no-underline text-black bg-white p-2.5 hover:bg-blue-200 border-b border-slate-200 inline-block overflow-ellipsis overflow-hidden whitespace-nowrap"
+              className="no-underline text-black bg-white p-2.5 hover:bg-blue-200 border-b border-slate-200 inline-block truncate"
               key={team.id}
             >
               <span className="font-semibold">{team.name} / </span>

--- a/client/src/pages/FavoritesPage.js
+++ b/client/src/pages/FavoritesPage.js
@@ -82,7 +82,7 @@ export const FavoritesPage = () => {
                       {listing.companyName}
                     </p>
                     <p className="font-bold mx-1 sm:mx-2 sm:text-lg">/</p>
-                    <p className="flex-nowrap text-xs overflow-hidden overflow-ellipsis whitespace-nowrap sm:px-0 sm:text-base">
+                    <p className="flex-nowrap text-xs truncate sm:px-0 sm:text-base">
                       {listing.jobTitle}
                     </p>
                   </div>

--- a/client/src/pages/UserPage.js
+++ b/client/src/pages/UserPage.js
@@ -35,7 +35,7 @@ export const UserPage = () => {
             <div className="flex items-center justify-center w-32 h-32 mt-8 rounded-full bg-slate-900 text-white font-bold">
               UI
             </div>
-            <div className="self-start">
+            <div className="self-start w-full">
               <UserInfo user={user} />
             </div>
           </div>

--- a/client/src/utils/trimUrl.js
+++ b/client/src/utils/trimUrl.js
@@ -1,0 +1,20 @@
+export default function trimUrl(url) {
+  if (url.startsWith("http://www.")) {
+    const http = "http://www.";
+    return url.slice(http.length);
+  }
+  if (url.startsWith("https://www.")) {
+    const http = "https://www.";
+    return url.slice(http.length);
+  }
+  if (url.startsWith("https://")) {
+    const https = "https://";
+    return url.slice(https.length);
+  }
+  if (url.startsWith("http://")) {
+    const http = "http://";
+    return url.slice(http.length);
+  }
+
+  return url;
+}


### PR DESCRIPTION
This PR:
- changes linkedin and github URLs strings to links
- adds truncate to UserInfo github, likedin, and email
- adds truncate to ListingPage apply link
- changes lengthy tailwind to shortcut `truncate` (app-wide)

<img width="1410" alt="Screen Shot 2023-05-25 at 4 06 21 PM" src="https://github.com/SVG-Productions/teamUpp/assets/100656411/38c446d2-0bdf-40cf-a8ea-8063e86ea2ba">
<img width="349" alt="Screen Shot 2023-05-25 at 4 06 38 PM" src="https://github.com/SVG-Productions/teamUpp/assets/100656411/abc2fbe1-06ac-4fa7-885a-fa9164c87d23">
<img width="886" alt="Screen Shot 2023-05-25 at 4 08 20 PM" src="https://github.com/SVG-Productions/teamUpp/assets/100656411/70e8b066-cca7-4ad3-a1bd-c9753ecf3c2e">
<img width="337" alt="Screen Shot 2023-05-25 at 4 08 06 PM" src="https://github.com/SVG-Productions/teamUpp/assets/100656411/3fb496c8-63b7-4815-af5a-7c605643aca7">
