### PR TITLE
Team privacy page

### DIFF
--- a/client/src/components/RequestToJoinForm.js
+++ b/client/src/components/RequestToJoinForm.js
@@ -1,5 +1,4 @@
 import axios from "axios";
-import { useState } from "react";
 import { useAuth } from "../context/AuthContext";
 import { useLoaderData } from "react-router-dom";
 import { toast } from "react-hot-toast";
@@ -9,17 +8,22 @@ const RequestToJoinForm = () => {
   const { authedUser } = useAuth();
   const { teamData } = useLoaderData();
 
-  const [submissionMessage, setSubmissionMessage] = useState("");
-  const [isSuccess, setIsSuccess] = useState(false);
-
   const handleRequest = async (e) => {
     e.preventDefault();
     try {
-      await axios.post(`/api/teams/${teamData.id}/teammates`, {
-        userId: authedUser.id,
-        status: "requested",
-      });
-      toast.success("Request sent successfully!", basicToast);
+      if (teamData.autoAccepts) {
+        await axios.post(`/api/teams/${teamData.id}/teammates`, {
+          userId: authedUser.id,
+          status: "member",
+        });
+        toast.success("Joined team successfully!", basicToast);
+      } else {
+        await axios.post(`/api/teams/${teamData.id}/teammates`, {
+          userId: authedUser.id,
+          status: "requested",
+        });
+        toast.success("Request sent successfully!", basicToast);
+      }
     } catch (error) {
       toast.error("Request or invite already pending.", basicToast);
     }

--- a/client/src/components/RequestToJoinForm.js
+++ b/client/src/components/RequestToJoinForm.js
@@ -1,12 +1,13 @@
 import axios from "axios";
 import { useAuth } from "../context/AuthContext";
-import { useLoaderData } from "react-router-dom";
+import { useLoaderData, useRevalidator } from "react-router-dom";
 import { toast } from "react-hot-toast";
 import { basicToast } from "../utils/toastOptions";
 
 const RequestToJoinForm = () => {
   const { authedUser } = useAuth();
   const { teamData } = useLoaderData();
+  const revalidator = useRevalidator();
 
   const handleRequest = async (e) => {
     e.preventDefault();
@@ -24,6 +25,7 @@ const RequestToJoinForm = () => {
         });
         toast.success("Request sent successfully!", basicToast);
       }
+      revalidator.revalidate();
     } catch (error) {
       toast.error("Request or invite already pending.", basicToast);
     }

--- a/client/src/pages/TeamMembersSettingsPage.js
+++ b/client/src/pages/TeamMembersSettingsPage.js
@@ -79,6 +79,7 @@ export const TeamMembersSettingsPage = () => {
         data: { userId },
       });
       revalidator.revalidate();
+      setOpenMemberMenu(null);
       toast.success("User successfully removed.", basicToast);
     } catch (error) {
       toast.error("Error removing user.", basicToast);

--- a/client/src/pages/TeamPrivacySettingsPage.js
+++ b/client/src/pages/TeamPrivacySettingsPage.js
@@ -37,8 +37,8 @@ export const TeamPrivacySettingsPage = () => {
         <h1 className="text-headingColor font-semibold pb-2 mb-4 border-b border-borderprimary">
           Privacy
         </h1>
-        <div className="flex justify-between mb-4">
-          <div className="flex flex-col">
+        <div className="flex justify-between items-center mb-4 p-1">
+          <div className="flex flex-col mr-2">
             <p className="font-bold">Change team visibility</p>
             <p>
               This team is currently{" "}
@@ -49,26 +49,47 @@ export const TeamPrivacySettingsPage = () => {
             </p>
           </div>
           {isPrivate ? (
-            <button onClick={() => handleSubmitPrivacy(false)}>
+            <button
+              className="text-sm min-w-fit h-[30px] text-primary px-2 bg-secondary rounded-md
+                    border border-slate-400 hover:border-slate-600 hover:bg-highlight"
+              onClick={() => handleSubmitPrivacy(false)}
+            >
               Make public
             </button>
           ) : (
-            <button onClick={() => handleSubmitPrivacy(true)}>
+            <button
+              className="text-sm min-w-fit h-[30px] text-primary px-2 bg-secondary rounded-md
+                    border border-slate-400 hover:border-slate-600 hover:bg-highlight"
+              onClick={() => handleSubmitPrivacy(true)}
+            >
               Make private
             </button>
           )}
         </div>
-        {/* <div className="flex justify-between">
-          <div className="flex flex-col">
-            <p className="font-bold">Change team visibility</p>
-            <p>This team is currently {isPrivate ? "private" : "public"}.</p>
+        <div className="flex justify-between items-center mb-4 p-1">
+          <div className="flex flex-col mr-2">
+            <p className="font-bold">Auto-accept requests</p>
+            <p>
+              This team currently {isPrivate ? "does" : "does not"} auto-accept
+              requests to join.
+            </p>
           </div>
           {isPrivate ? (
-            <button>Make public</button>
+            <button
+              className="text-sm min-w-fit h-[30px] text-primary px-2 bg-secondary rounded-md
+                    border border-slate-400 hover:border-slate-600 hover:bg-highlight"
+            >
+              Enable auto-accept
+            </button>
           ) : (
-            <button>Make private</button>
+            <button
+              className="text-sm min-w-fit h-[30px] text-primary px-2 bg-secondary rounded-md
+                    border border-slate-400 hover:border-slate-600 hover:bg-highlight"
+            >
+              Disable auto-accept
+            </button>
           )}
-        </div> */}
+        </div>
       </div>
     </div>
   );

--- a/client/src/pages/TeamPrivacySettingsPage.js
+++ b/client/src/pages/TeamPrivacySettingsPage.js
@@ -6,14 +6,19 @@ import { basicToast } from "../utils/toastOptions";
 
 export const TeamPrivacySettingsPage = () => {
   const { teamData } = useRouteLoaderData("teamSettings");
-
-  const [isPrivate, setIsPrivate] = useState(teamData.isPrivate);
+  const { jobField, name, isPrivate } = teamData;
 
   const revalidator = useRevalidator();
 
-  const handleSubmit = async (e) => {
+  const handleSubmitPrivacy = async (privacy) => {
     try {
-      const updates = { isPrivate };
+      // TODO: The update validators across the app require certain
+      // fields to be present, even if the field is not being changed.
+      // This creates a problem since we need validators to make sure
+      // no bad data is sent to the API. Need to think of a different
+      // approach for PATCH requests and validations.
+
+      const updates = { isPrivate: privacy, jobField, name };
       await axios.patch(`/api/teams/${teamData.id}`, updates);
 
       revalidator.revalidate();
@@ -44,12 +49,16 @@ export const TeamPrivacySettingsPage = () => {
             </p>
           </div>
           {isPrivate ? (
-            <button>Make public</button>
+            <button onClick={() => handleSubmitPrivacy(false)}>
+              Make public
+            </button>
           ) : (
-            <button>Make private</button>
+            <button onClick={() => handleSubmitPrivacy(true)}>
+              Make private
+            </button>
           )}
         </div>
-        <div className="flex justify-between">
+        {/* <div className="flex justify-between">
           <div className="flex flex-col">
             <p className="font-bold">Change team visibility</p>
             <p>This team is currently {isPrivate ? "private" : "public"}.</p>
@@ -59,7 +68,7 @@ export const TeamPrivacySettingsPage = () => {
           ) : (
             <button>Make private</button>
           )}
-        </div>
+        </div> */}
       </div>
     </div>
   );

--- a/client/src/pages/TeamPrivacySettingsPage.js
+++ b/client/src/pages/TeamPrivacySettingsPage.js
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useRevalidator, useRouteLoaderData } from "react-router-dom";
 import axios from "axios";
 import { toast } from "react-hot-toast";
@@ -6,8 +5,7 @@ import { basicToast } from "../utils/toastOptions";
 
 export const TeamPrivacySettingsPage = () => {
   const { teamData } = useRouteLoaderData("teamSettings");
-  const { jobField, name, isPrivate } = teamData;
-
+  const { jobField, name, isPrivate, autoAccepts } = teamData;
   const revalidator = useRevalidator();
 
   const handleSubmitPrivacy = async (privacy) => {
@@ -19,6 +17,18 @@ export const TeamPrivacySettingsPage = () => {
       // approach for PATCH requests and validations.
 
       const updates = { isPrivate: privacy, jobField, name };
+      await axios.patch(`/api/teams/${teamData.id}`, updates);
+
+      revalidator.revalidate();
+      toast.success("Team successfully updated!", basicToast);
+    } catch (error) {
+      toast.error("Oops! Something went wrong.", basicToast);
+    }
+  };
+
+  const handleSubmitAutoAccept = async (accepts) => {
+    try {
+      const updates = { autoAccepts: accepts, jobField, name };
       await axios.patch(`/api/teams/${teamData.id}`, updates);
 
       revalidator.revalidate();
@@ -41,11 +51,9 @@ export const TeamPrivacySettingsPage = () => {
           <div className="flex flex-col mr-2">
             <p className="font-bold">Change team visibility</p>
             <p>
-              This team is currently{" "}
-              {isPrivate
-                ? "private and cannot be searched"
-                : "public and can be searched"}
-              .
+              This team is currently
+              {isPrivate ? " private and cannot " : " public and can "}
+              be searched.
             </p>
           </div>
           {isPrivate ? (
@@ -70,23 +78,26 @@ export const TeamPrivacySettingsPage = () => {
           <div className="flex flex-col mr-2">
             <p className="font-bold">Auto-accept requests</p>
             <p>
-              This team currently {isPrivate ? "does" : "does not"} auto-accept
+              This team currently
+              {autoAccepts ? " auto-accepts " : " does not auto-accept "}
               requests to join.
             </p>
           </div>
-          {isPrivate ? (
+          {autoAccepts ? (
             <button
               className="text-sm min-w-fit h-[30px] text-primary px-2 bg-secondary rounded-md
                     border border-slate-400 hover:border-slate-600 hover:bg-highlight"
+              onClick={() => handleSubmitAutoAccept(false)}
             >
-              Enable auto-accept
+              Disable auto-accept
             </button>
           ) : (
             <button
               className="text-sm min-w-fit h-[30px] text-primary px-2 bg-secondary rounded-md
                     border border-slate-400 hover:border-slate-600 hover:bg-highlight"
+              onClick={() => handleSubmitAutoAccept(true)}
             >
-              Disable auto-accept
+              Enable auto-accept
             </button>
           )}
         </div>

--- a/client/src/pages/TeamPrivacySettingsPage.js
+++ b/client/src/pages/TeamPrivacySettingsPage.js
@@ -82,6 +82,10 @@ export const TeamPrivacySettingsPage = () => {
               {autoAccepts ? " auto-accepts " : " does not auto-accept "}
               requests to join.
             </p>
+            <p className="text-xs text-secondary">
+              This only applies to future requests. Current requests will need
+              to be accepted.
+            </p>
           </div>
           {autoAccepts ? (
             <button

--- a/client/src/pages/TeamPrivacySettingsPage.js
+++ b/client/src/pages/TeamPrivacySettingsPage.js
@@ -1,6 +1,28 @@
-import React from "react";
+import { useState } from "react";
+import { useRevalidator, useRouteLoaderData } from "react-router-dom";
+import axios from "axios";
+import { toast } from "react-hot-toast";
+import { basicToast } from "../utils/toastOptions";
 
 export const TeamPrivacySettingsPage = () => {
+  const { teamData } = useRouteLoaderData("teamSettings");
+
+  const [isPrivate, setIsPrivate] = useState(teamData.isPrivate);
+
+  const revalidator = useRevalidator();
+
+  const handleSubmit = async (e) => {
+    try {
+      const updates = { isPrivate };
+      await axios.patch(`/api/teams/${teamData.id}`, updates);
+
+      revalidator.revalidate();
+      toast.success("Team successfully updated!", basicToast);
+    } catch (error) {
+      toast.error("Oops! Something went wrong.", basicToast);
+    }
+  };
+
   return (
     <div
       className="flex flex-col flex-grow self-center w-full
@@ -8,8 +30,36 @@ export const TeamPrivacySettingsPage = () => {
     >
       <div className="w-full">
         <h1 className="text-headingColor font-semibold pb-2 mb-4 border-b border-borderprimary">
-          Privacy -- Coming soon!
+          Privacy
         </h1>
+        <div className="flex justify-between mb-4">
+          <div className="flex flex-col">
+            <p className="font-bold">Change team visibility</p>
+            <p>
+              This team is currently{" "}
+              {isPrivate
+                ? "private and cannot be searched"
+                : "public and can be searched"}
+              .
+            </p>
+          </div>
+          {isPrivate ? (
+            <button>Make public</button>
+          ) : (
+            <button>Make private</button>
+          )}
+        </div>
+        <div className="flex justify-between">
+          <div className="flex flex-col">
+            <p className="font-bold">Change team visibility</p>
+            <p>This team is currently {isPrivate ? "private" : "public"}.</p>
+          </div>
+          {isPrivate ? (
+            <button>Make public</button>
+          ) : (
+            <button>Make private</button>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/server/migrations/20230608214635_team_auto_accepts.js
+++ b/server/migrations/20230608214635_team_auto_accepts.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  await knex.schema.alterTable("teams", function (table) {
+    table.boolean("auto_accepts").defaultTo(false);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  await knex.schema.alterTable("teams", function (table) {
+    table.dropColumn("auto_accepts");
+  });
+};

--- a/server/models/Team.js
+++ b/server/models/Team.js
@@ -66,7 +66,7 @@ const getSingleTeam = async (teamId) => {
 };
 
 const addUserToTeam = async (userId, teamId, status) => {
-  const approvedStatuses = ["owner", "invited", "requested"];
+  const approvedStatuses = ["owner", "invited", "requested", "member"];
   try {
     if (!approvedStatuses.includes(status)) {
       throw new Error("Invalid status");


### PR DESCRIPTION
- Implements UI for TeamPrivacySettingsPage
- Creates migration to allow for new feature: auto-accepting requests to join team
    - Teams can now enable/disable auto-accepting requests
    - Changes RequestToJoinForm to add logic based on team's "autoAccepts" property
    - adds approved status "member" to addUserToTeam model
 

![image](https://github.com/SVG-Productions/teamUpp/assets/40076376/7b8bafb1-bf0b-4fb4-9480-a63f2cc16b15)
![image](https://github.com/SVG-Productions/teamUpp/assets/40076376/ee39a980-4c8d-4118-97ba-01c7ef1b7f67)
