### PR TITLE
Separate loaders for applications pages

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -44,10 +44,10 @@ import {
 import { ForgotPasswordPage } from "./pages/ForgotPasswordPage";
 import { ResetPasswordPage } from "./pages/ResetPasswordPage";
 import ContactUsPage from "./pages/ContactUsPage";
-import { AppsLayout, appsLayoutLoader } from "./layouts/AppsLayout";
-import { AppsBoardPage } from "./pages/AppsBoardPage";
+import { AppsLayout } from "./layouts/AppsLayout";
+import { AppsBoardPage, appsBoardLoader } from "./pages/AppsBoardPage";
 import { BoardProvider } from "./context/BoardContext";
-import { AppsListPage } from "./pages/AppsListPage";
+import { AppsListPage, appsListLoader } from "./pages/AppsListPage";
 
 const router = createBrowserRouter([
   {
@@ -102,7 +102,6 @@ const router = createBrowserRouter([
       {
         path: "/:username/apps",
         element: <AppsLayout />,
-        loader: appsLayoutLoader,
         id: "apps",
         children: [
           {
@@ -116,10 +115,12 @@ const router = createBrowserRouter([
                 <AppsBoardPage />
               </BoardProvider>
             ),
+            loader: appsListLoader,
           },
           {
             path: "list",
             element: <AppsListPage />,
+            loader: appsBoardLoader,
           },
         ],
       },

--- a/client/src/context/BoardContext.tsx
+++ b/client/src/context/BoardContext.tsx
@@ -1,12 +1,12 @@
 import React, { useState, createContext, useContext } from "react";
-import { useRouteLoaderData } from "react-router-dom";
+import { useLoaderData } from "react-router-dom";
 import { UserType } from "../../type-definitions";
 
 const BoardContext = createContext<any>({});
 
 export const useBoard = () => useContext(BoardContext);
 export const BoardProvider = ({ children }: { children: any }) => {
-  const { userData } = useRouteLoaderData("apps") as {
+  const { userData } = useLoaderData() as {
     userData: UserType;
   };
   const [boardData, setBoardData] = useState<any>({

--- a/client/src/layouts/AppsLayout.tsx
+++ b/client/src/layouts/AppsLayout.tsx
@@ -1,25 +1,16 @@
 import React from "react";
-import {
-  NavLink,
-  Navigate,
-  Outlet,
-  Params,
-  useParams,
-  useRouteLoaderData,
-} from "react-router-dom";
+import { NavLink, Navigate, Outlet, useParams } from "react-router-dom";
 import AuthedPageTitle from "../components/AuthedPageTitle";
-import axios from "axios";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChalkboard, faList } from "@fortawesome/free-solid-svg-icons";
 import { useAuth } from "../context/AuthContext";
-import { UserType } from "../../type-definitions";
 
 export const AppsLayout = () => {
   const { authedUser } = useAuth();
   const { username } = useParams();
-  const { userData } = useRouteLoaderData("apps") as {
-    userData: UserType;
-  };
+
+  console.log(authedUser);
+
   const isAuthorizedUser = authedUser?.username === username;
 
   const activateSidebarLinks = ({ isActive }: { isActive: boolean }) => {
@@ -34,7 +25,7 @@ export const AppsLayout = () => {
     <>
       <AuthedPageTitle
         links={[
-          { to: `/${userData.username}`, label: userData.username },
+          { to: `/${authedUser?.username}`, label: authedUser?.username },
           { to: "", label: "MyApps" },
         ]}
       />
@@ -46,21 +37,22 @@ export const AppsLayout = () => {
                 className="w-7 h-7 rounded-full mr-3 sm:w-10 sm:h-10"
                 width={40}
                 height={40}
-                alt={userData.username}
+                alt={authedUser?.username}
                 src={authedUser?.photo || authedUser?.avatar}
               />
               <h1 className="text-base sm:text-2xl">
                 <NavLink
-                  to={`/${userData.username}`}
+                  to={`/${authedUser?.username}`}
                   className="no-underline font-semibold text-primary hover:underline"
                 >
-                  {userData.firstName}
-                  <span className="text-slate-600"> ({userData.username})</span>
+                  <span className="text-slate-600">
+                    ({authedUser?.username})
+                  </span>
                 </NavLink>
               </h1>
             </div>
             <NavLink
-              to={`/${userData.username}`}
+              to={`/${authedUser?.username}`}
               className="no-underline font-semibold text-sm min-w-fit text-primary p-2 bg-secondary rounded-md
             border border-slate-400 hover:border-slate-600 hover:bg-highlight sm:text-base"
             >
@@ -100,25 +92,4 @@ export const AppsLayout = () => {
       </div>
     </>
   );
-};
-
-export const appsLayoutLoader = async ({
-  request,
-  params,
-}: {
-  request: Request;
-  params: Params;
-}) => {
-  const url = new URL(request.url);
-  const searchParams = new URLSearchParams(url.search);
-  const appsListParams = {
-    sort: searchParams.get("sort"),
-    search: searchParams.get("search"),
-    page: searchParams.get("page"),
-  };
-  const userResponse = await axios.get("/api/users/user", {
-    params: appsListParams,
-  });
-  const userData = userResponse.data;
-  return { userData };
 };

--- a/client/src/pages/AppsBoardPage.tsx
+++ b/client/src/pages/AppsBoardPage.tsx
@@ -22,6 +22,7 @@ import useOnClickOutside from "../hooks/useOnClickOutside";
 import { useBoard } from "../context/BoardContext";
 import BoardAppDetailsModal from "../components/BoardAppDetailsModal";
 import CreateBoardAppModal from "../components/CreateBoardAppModal";
+import { Params } from "react-router-dom";
 
 export const AppsBoardPage = () => {
   const {
@@ -332,4 +333,16 @@ export const AppsBoardPage = () => {
       </div>
     </>
   );
+};
+
+export const appsBoardLoader = async ({
+  request,
+  params,
+}: {
+  request: Request;
+  params: Params;
+}) => {
+  const userResponse = await axios.get("/api/users/user");
+  const userData = userResponse.data;
+  return { userData };
 };

--- a/client/src/pages/AppsListPage.tsx
+++ b/client/src/pages/AppsListPage.tsx
@@ -10,15 +10,16 @@ import {
   faSearch,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { useRouteLoaderData, useSearchParams } from "react-router-dom";
+import { Params, useLoaderData, useSearchParams } from "react-router-dom";
 import { ListingType, UserType } from "../../type-definitions";
 import NullInfo from "../components/NullInfo";
 import Pagination from "../components/Pagination";
 import { formatGeneralDate } from "../utils/dateFormatters";
 import { formatSalary } from "../utils/formatSalary";
+import axios from "axios";
 
 export const AppsListPage = () => {
-  const { userData } = useRouteLoaderData("apps") as { userData: UserType };
+  const { userData } = useLoaderData() as { userData: UserType };
   const applicationColumns = userData.applications.boardApps.columns;
   const [searchInput, setSearchInput] = useState("");
   const [selectedColumn, setSelectedColumn] = useState("");
@@ -228,4 +229,25 @@ export const AppsListPage = () => {
       <Pagination count={`${userData.applications.listings.length}`} />
     </>
   );
+};
+
+export const appsListLoader = async ({
+  request,
+  params,
+}: {
+  request: Request;
+  params: Params;
+}) => {
+  const url = new URL(request.url);
+  const searchParams = new URLSearchParams(url.search);
+  const appsListParams = {
+    sort: searchParams.get("sort"),
+    search: searchParams.get("search"),
+    page: searchParams.get("page"),
+  };
+  const userResponse = await axios.get("/api/users/user", {
+    params: appsListParams,
+  });
+  const userData = userResponse.data;
+  return { userData };
 };


### PR DESCRIPTION
This PR:
- removes applications layout loader 
- adds separate loaders for applications board and applications list pages
- removes use of layout loader from board context (replaced with authedUser context)